### PR TITLE
Add event-log

### DIFF
--- a/src/cli/default.nix
+++ b/src/cli/default.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
 
   # This hash should be the output of:
   #   go mod vendor && nix-hash --base32 --type sha256 vendor
-  vendorSha256 = "1yirdqkwnaz0iikcipn1nxcgv2ywrg0zhwjklzf6xns8w038bylp";
+  vendorSha256 = "03k976xhy5gpc5zabm5msa0i0ql7g9l5hb8v7kwk0rrb92gsi8bj";
 
   buildFlagsArray =
     [ "-ldflags=-X main.version=${lib.commitIdFromGitRepo ./../../.git}" ];

--- a/src/db/migrations/1609756790_add_event_log.sql
+++ b/src/db/migrations/1609756790_add_event_log.sql
@@ -1,0 +1,10 @@
+-- +migrate Up
+CREATE TABLE IF NOT EXISTS event_log (
+  id           INTEGER  PRIMARY KEY,
+  event        TEXT     NOT NULL,
+  meta         JSON     NOT NULL,
+  data         JSON     NOT NULL,
+  at           DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')));
+
+-- +migrate Down
+DROP TABLE IF EXISTS event_log;

--- a/src/debugger/default.nix
+++ b/src/debugger/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   buildInputs = [ detsysLib ];
   propagatedBuildInputs = [ plantuml ];
 
-  vendorSha256 = "1ar210dpgf1j9kprzbi8ff4p07kb40qmvdyilzk5aakd1hzxll9p";
+  vendorSha256 = "0s0gzn39sdqf77jykmixp7zbj994qhzsasd0l166wp2mg6nnljqz";
 
   buildFlagsArray =
     [ "-ldflags=-X main.version=${lib.commitIdFromGitRepo ./../../.git}" ];

--- a/src/executor/executor.go
+++ b/src/executor/executor.go
@@ -21,8 +21,10 @@ func jsonError(s string) string {
 type ComponentUpdate = func(component string, at time.Time)
 type Topology = map[string]lib.Reactor
 
-func handler(db *sql.DB, testId lib.TestId, topology Topology, m lib.Marshaler, cu ComponentUpdate) http.HandlerFunc {
+func handler(db *sql.DB, testId lib.TestId, eventLog lib.EventLogEmitter, topology Topology, m lib.Marshaler, cu ComponentUpdate) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		eventLog.Emit("handleReceive", "Start")
+		defer eventLog.Emit("handleReceive", "End")
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		if r.Method != "POST" {
 			http.Error(w, jsonError("Method is not supported."),
@@ -41,6 +43,7 @@ func handler(db *sql.DB, testId lib.TestId, topology Topology, m lib.Marshaler, 
 			panic(err)
 		}
 		cu(sev.To, sev.At)
+		// TODO(danne) these should also be events
 		heapBefore := dumpHeapJson(topology[sev.To])
 		oevs := topology[sev.To].Receive(sev.At, sev.From, sev.Event)
 		heapAfter := dumpHeapJson(topology[sev.To])
@@ -51,12 +54,14 @@ func handler(db *sql.DB, testId lib.TestId, topology Topology, m lib.Marshaler, 
 	}
 }
 
-func handleTick(topology Topology, m lib.Marshaler, cu ComponentUpdate) http.HandlerFunc {
+func handleTick(eventLog lib.EventLogEmitter, topology Topology, m lib.Marshaler, cu ComponentUpdate) http.HandlerFunc {
 	type TickRequest struct {
 		Component string    `json:"component"`
 		At        time.Time `json:"at"`
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
+		eventLog.Emit("handleTick", "Start")
+		defer eventLog.Emit("handleTick", "End")
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		if r.Method != "PUT" {
 			http.Error(w, jsonError("Method is not supported."),
@@ -79,13 +84,15 @@ func handleTick(topology Topology, m lib.Marshaler, cu ComponentUpdate) http.Han
 	}
 }
 
-func handleTimer(db *sql.DB, testId lib.TestId, topology Topology, m lib.Marshaler, cu ComponentUpdate) http.HandlerFunc {
+func handleTimer(db *sql.DB, testId lib.TestId, eventLog lib.EventLogEmitter, topology Topology, m lib.Marshaler, cu ComponentUpdate) http.HandlerFunc {
 	type TimerRequest struct {
 		Component string    `json:"to"`
 		At        time.Time `json:"at"`
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
+		eventLog.Emit("handleTimer", "Start")
+		defer eventLog.Emit("handleTimer", "End")
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		if r.Method != "POST" {
 			http.Error(w, jsonError("Method is not supported."),
@@ -113,7 +120,9 @@ func handleTimer(db *sql.DB, testId lib.TestId, topology Topology, m lib.Marshal
 	}
 }
 
-func Register(topology Topology) {
+func Register(eventLog lib.EventLogEmitter, topology Topology) {
+	eventLog.Emit("Register Executor", "Start")
+	defer eventLog.Emit("Register Executor", "End")
 	// TODO(stevan): Make executorUrl part of topology.
 	const executorUrl string = "http://localhost:3001/api/v1/"
 
@@ -124,32 +133,34 @@ func Register(topology Topology) {
 	lib.RegisterExecutor(executorUrl, components)
 }
 
-func DeployWithComponentUpdate(srv *http.Server, testId lib.TestId, topology Topology, m lib.Marshaler, cu ComponentUpdate) {
+func DeployWithComponentUpdate(srv *http.Server, testId lib.TestId, eventLog lib.EventLogEmitter, topology Topology, m lib.Marshaler, cu ComponentUpdate) {
+	eventLog.Emit("Deploy Executor", "Start")
+	defer eventLog.Emit("Deploy Executor", "End")
 	mux := http.NewServeMux()
 
 	db := lib.OpenDB()
-	mux.HandleFunc("/api/v1/event", handler(db, testId, topology, m, cu))
-	mux.HandleFunc("/api/v1/tick", handleTick(topology, m, cu))
-	mux.HandleFunc("/api/v1/timer", handleTimer(db, testId, topology, m, cu))
+	defer db.Close()
+	mux.HandleFunc("/api/v1/event", handler(db, testId, eventLog, topology, m, cu))
+	mux.HandleFunc("/api/v1/tick", handleTick(eventLog, topology, m, cu))
+	mux.HandleFunc("/api/v1/timer", handleTimer(db, testId, eventLog, topology, m, cu))
 	srv.Addr = ":3001"
 	srv.Handler = mux
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 		panic(err)
 	}
-	defer db.Close()
 }
 
-func Deploy(srv *http.Server, testId lib.TestId, topology Topology, m lib.Marshaler) {
-	DeployWithComponentUpdate(srv, testId, topology, m, func(string, time.Time) {})
+func Deploy(srv *http.Server, testId lib.TestId, eventLog lib.EventLogEmitter, topology Topology, m lib.Marshaler) {
+	DeployWithComponentUpdate(srv, testId, eventLog, topology, m, func(string, time.Time) {})
 }
 
-func DeployRaw(srv *http.Server, testId lib.TestId, topology map[string]string, m lib.Marshaler, constructor func(string) lib.Reactor) {
+func DeployRaw(srv *http.Server, testId lib.TestId, eventLog lib.EventLogEmitter, topology map[string]string, m lib.Marshaler, constructor func(string) lib.Reactor) {
 	topologyCooked := make(Topology, len(topology))
 	for name, component := range topology {
 		topologyCooked[name] = constructor(component)
 	}
 
-	Deploy(srv, testId, topologyCooked, m)
+	Deploy(srv, testId, eventLog, topologyCooked, m)
 }
 
 type LogWriter struct {
@@ -188,6 +199,7 @@ type Executor struct {
 	testId      lib.TestId
 	runId       lib.RunId
 	constructor func(name string, logger *zap.Logger) lib.Reactor
+	eventLog    lib.EventLogEmitter
 	logger      *zap.Logger
 }
 
@@ -203,7 +215,6 @@ func (e *Executor) SetTestId(testId lib.TestId) {
 }
 
 func NewExecutor(testId lib.TestId, marshaler lib.Marshaler, logger *zap.Logger, components []string, constructor func(name string, logger *zap.Logger) lib.Reactor) *Executor {
-
 	runId := lib.RunId{0}
 
 	topology := make(map[string]lib.Reactor)
@@ -220,19 +231,29 @@ func NewExecutor(testId lib.TestId, marshaler lib.Marshaler, logger *zap.Logger,
 		buffers[component] = buffer
 	}
 
-	return &Executor{
+	executor := &Executor{
 		topology:    topology,
 		buffers:     buffers,
 		marshaler:   marshaler,
 		testId:      testId,
 		runId:       runId,
 		constructor: constructor,
-		logger:      logger,
+		eventLog: lib.EventLogEmitter{
+			Component: "Executor",
+			TestId:    nil,
+			RunId:     nil,
+		},
+		logger: logger,
 	}
+
+	executor.eventLog.TestId = &executor.testId
+	executor.eventLog.RunId = &executor.runId
+
+	return executor
 }
 
 func (e *Executor) Deploy(srv *http.Server) {
-	DeployWithComponentUpdate(srv, e.testId, e.topology, e.marshaler, func(name string, at time.Time) {
+	DeployWithComponentUpdate(srv, e.testId, e.eventLog, e.topology, e.marshaler, func(name string, at time.Time) {
 		buffer, ok := e.buffers[name]
 
 		if ok {
@@ -244,10 +265,11 @@ func (e *Executor) Deploy(srv *http.Server) {
 }
 
 func (e *Executor) Register() {
-	Register(e.topology)
+	Register(e.eventLog, e.topology)
 }
 
 func (e *Executor) Reset(runId lib.RunId) {
+	e.runId = runId
 	for c, b := range e.buffers {
 		b.runId = runId
 		b.at = time.Time{}

--- a/src/lib/event.go
+++ b/src/lib/event.go
@@ -1,0 +1,52 @@
+package lib
+
+import (
+	"encoding/json"
+)
+
+type EventLogEmitter struct {
+	Component string
+	RunId     *RunId  // maybe we have one
+	TestId    *TestId // maybe we have one
+}
+
+func (meta *EventLogEmitter) EmitData(event string, state string, data interface{}) {
+	metaBlob, err := json.Marshal(struct {
+		State     string  `json:"state"`
+		Component string  `json:"component"`
+		RunId     *RunId  `json:"run-id"`
+		TestId    *TestId `json:"test-id"`
+	}{
+		State:     state,
+		Component: meta.Component,
+		RunId:     meta.RunId,
+		TestId:    meta.TestId,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	dataBlob, err := json.Marshal(data)
+	if err != nil {
+		panic(err)
+	}
+
+	db := OpenDB()
+	defer db.Close()
+
+	stmt, err := db.Prepare(`INSERT INTO event_log(event, meta, data) VALUES(?,?,?)`)
+	if err != nil {
+		panic(err)
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(event, metaBlob, dataBlob)
+
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (emitter *EventLogEmitter) Emit(event string, state string) {
+	emitter.EmitData(event, state, struct{}{})
+}

--- a/src/scheduler/src/scheduler/db.clj
+++ b/src/scheduler/src/scheduler/db.clj
@@ -84,3 +84,18 @@
       VALUES (?, ?, ?, ?)"
     test-id run-id logical-time simulated-time]
    {:return-keys true :builder-fn rs/as-unqualified-lower-maps}))
+
+(defn append-event!
+  ([test-id run-id event state]
+   (append-event! test-id run-id event state {}))
+  ([test-id run-id event state data]
+   (jdbc/execute-one!
+    ds
+    ["INSERT INTO event_log (event, meta, data) VALUES (?,?,?)"
+     event
+     (json/write {:component "scheduler"
+                  :state state
+                  :test-id test-id
+                  :run-id run-id})
+     (json/write data)]
+    {:return-keys true :builder-fn rs/as-unqualified-lower-maps})))

--- a/src/scheduler/src/scheduler/pure.clj
+++ b/src/scheduler/src/scheduler/pure.clj
@@ -377,10 +377,12 @@
                   [data' {:events []}])
                 (let ;; TODO(stevan): Retry on failure, this possibly needs changes to executor
                     ;; so that we don't end up executing the same command twice.
-                    [events (-> (client/post (str url (if (= (:kind body) "timer") "timer" "event"))
+                    [_ (db/append-event! (:test-id data) (:run-id data) "Send message to executor" "Start")
+                     events (-> (client/post (str url (if (= (:kind body) "timer") "timer" "event"))
                                              {:body (json/write body) :content-type "application/json; charset=utf-8"})
                                 :body
-                          json/read)]
+                                json/read)
+                     _ (db/append-event! (:test-id data) (:run-id data) "Send message to executor" "End")]
                   ;; TODO(stevan): go into error state if response body is of form {"error": ...}
                   ;; (if (:error events) true false)
 
@@ -641,11 +643,13 @@
 (>defn step!
   [data]
   [::data => (s/tuple ::data (s/keys :req-un [::events ::queue-size]))]
+  (db/append-event! (:test-id data) (:run-id data) "step!" "Start")
   (let [[data' events] (execute-or-tick! data)
         [data'' timestamped-entries] (timestamp-entries data'
                                                         (:events events)
                                                         (-> data' :clock))
         [data''' queue-size] (enqueue-timestamped-entries data'' timestamped-entries)]
+    (db/append-event! (:test-id data) (:run-id data) "step!" "End")
     [data''' (merge events queue-size)]))
 
 (comment


### PR DESCRIPTION
This is an table that should contain all "events" that happen in
order to make a simulation. Which can be used for debugging (get a
global log of what the testing framework did) and a distributed profiling.