### PR TITLE
perf(executor+scheduler): Remove events only used for profiling

### DIFF
--- a/src/executor/executor.go
+++ b/src/executor/executor.go
@@ -23,8 +23,6 @@ type Topology = map[string]lib.Reactor
 
 func handler(db *sql.DB, testId lib.TestId, eventLog lib.EventLogEmitter, topology Topology, m lib.Marshaler, cu ComponentUpdate) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		eventLog.Emit("handleReceive", "Start")
-		defer eventLog.Emit("handleReceive", "End")
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		if r.Method != "POST" {
 			http.Error(w, jsonError("Method is not supported."),
@@ -60,8 +58,6 @@ func handleTick(eventLog lib.EventLogEmitter, topology Topology, m lib.Marshaler
 		At        time.Time `json:"at"`
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
-		eventLog.Emit("handleTick", "Start")
-		defer eventLog.Emit("handleTick", "End")
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		if r.Method != "PUT" {
 			http.Error(w, jsonError("Method is not supported."),
@@ -91,8 +87,6 @@ func handleTimer(db *sql.DB, testId lib.TestId, eventLog lib.EventLogEmitter, to
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		eventLog.Emit("handleTimer", "Start")
-		defer eventLog.Emit("handleTimer", "End")
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		if r.Method != "POST" {
 			http.Error(w, jsonError("Method is not supported."),
@@ -152,8 +146,6 @@ func handleInits(topology Topology, m lib.Marshaler) http.HandlerFunc {
 }
 
 func DeployWithComponentUpdate(srv *http.Server, testId lib.TestId, eventLog lib.EventLogEmitter, topology Topology, m lib.Marshaler, cu ComponentUpdate) {
-	eventLog.Emit("Deploy Executor", "Start")
-	defer eventLog.Emit("Deploy Executor", "End")
 	mux := http.NewServeMux()
 
 	db := lib.OpenDB()
@@ -321,7 +313,7 @@ func (e *Executor) Deploy(srv *http.Server) {
 }
 
 func (e *Executor) Register() {
-	lib.Register(e.eventLog, e.testId)
+	lib.Register(e.testId)
 }
 
 func (e *Executor) Reset(runId lib.RunId) {

--- a/src/executor/heap_trace.go
+++ b/src/executor/heap_trace.go
@@ -27,18 +27,20 @@ func jsonDiff(original []byte, modified []byte) []byte {
 }
 
 func appendHeapTrace(db *sql.DB, testId lib.TestId, component string, diff []byte, at time.Time) {
-	stmt, err := db.Prepare("SELECT MAX(id) FROM run WHERE test_id = ?")
-	if err != nil {
-		panic(err)
-	}
-	defer stmt.Close()
-
 	var runId lib.RunId
-	if err := stmt.QueryRow(testId.TestId).Scan(&runId.RunId); err != nil {
-		panic(err)
+	{
+		stmt, err := db.Prepare("SELECT MAX(id) FROM run WHERE test_id = ?")
+		if err != nil {
+			panic(err)
+		}
+		defer stmt.Close()
+
+		if err := stmt.QueryRow(testId.TestId).Scan(&runId.RunId); err != nil {
+			panic(err)
+		}
 	}
 
-	stmt, err = db.Prepare(`INSERT INTO heap_trace(test_id, run_id, id, component, heap, at)
+	stmt, err := db.Prepare(`INSERT INTO heap_trace(test_id, run_id, id, component, heap, at)
                                 VALUES(?, ?,
                                   (SELECT IFNULL(MAX(id), -1) + 1 FROM heap_trace
                                    WHERE test_id = ?

--- a/src/lib/scheduler.go
+++ b/src/lib/scheduler.go
@@ -143,9 +143,7 @@ func componentsFromDeployment(testId TestId) ([]string, error) {
 	return components, nil
 }
 
-func Register(eventLog EventLogEmitter, testId TestId) {
-	eventLog.Emit("Register Executor", "Start")
-	defer eventLog.Emit("Register Executor", "End")
+func Register(testId TestId) {
 	// TODO(stevan): Make executorUrl part of topology/deployment.
 	const executorUrl string = "http://localhost:3001/api/v1/"
 

--- a/src/scheduler/src/scheduler/handler.clj
+++ b/src/scheduler/src/scheduler/handler.clj
@@ -26,20 +26,10 @@
     (log/debug :body edn)
     (log/debug :handler-state (:state @data))
     (if (s/valid? command? edn)
-      (let [_ (db/append-event! (:test-id data)
-                                (:run-id data)
-                                (:command edn)
-                                "Start"
-                                (:parameters edn))
-            parameters (:parameters edn)
+      (let [parameters (:parameters edn)
             [data' output] (call (:command edn) (if (empty? parameters)
                                                   [@data]
                                                   [@data parameters]))]
-        (db/append-event! (:test-id data)
-                          (:run-id data)
-                          (:command edn)
-                          "End"
-                          (:parameters edn))
         (if (pure/error-state? (:state data'))
           {:status 400
            :headers {"Content-Type" "application/json; charset=utf-8"}

--- a/src/scheduler/src/scheduler/pure.clj
+++ b/src/scheduler/src/scheduler/pure.clj
@@ -380,12 +380,10 @@
                   [data' {:events []}])
                 (let ;; TODO(stevan): Retry on failure, this possibly needs changes to executor
                     ;; so that we don't end up executing the same command twice.
-                    [_ (db/append-event! (:test-id data) (:run-id data) "Send message to executor" "Start")
-                     events (-> (client/post (str url (if (= (:kind body) "timer") "timer" "event"))
+                    [events (-> (client/post (str url (if (= (:kind body) "timer") "timer" "event"))
                                              {:body (json/write body) :content-type "application/json; charset=utf-8"})
                                 :body
-                                json/read)
-                     _ (db/append-event! (:test-id data) (:run-id data) "Send message to executor" "End")]
+                                json/read)]
                   ;; TODO(stevan): go into error state if response body is of form {"error": ...}
                   ;; (if (:error events) true false)
 
@@ -703,13 +701,11 @@
 (>defn step!
   [data]
   [::data => (s/tuple ::data (s/keys :req-un [::events ::queue-size]))]
-  (db/append-event! (:test-id data) (:run-id data) "step!" "Start")
   (let [[data' events] (execute-or-tick! data)
         [data'' timestamped-entries] (timestamp-entries data'
                                                         (:events events)
                                                         (-> data' :clock))
         [data''' queue-size] (enqueue-timestamped-entries data'' timestamped-entries)]
-    (db/append-event! (:test-id data) (:run-id data) "step!" "End")
     [data''' (merge events queue-size)]))
 
 (comment

--- a/src/sut/broadcast/broadcast_test.go
+++ b/src/sut/broadcast/broadcast_test.go
@@ -28,7 +28,7 @@ func once(round Round, testId lib.TestId, t *testing.T) (lib.RunId, bool) {
 	})
 	qs := lib.LoadTest(testId)
 	log.Printf("Loaded test of size: %d\n", qs.QueueSize)
-	lib.Register(eventLog, testId)
+	lib.Register(testId)
 	log.Printf("Registered executor")
 	runId := lib.CreateRun(testId)
 	eventLog.RunId = &runId

--- a/src/sut/register/example_test.go
+++ b/src/sut/register/example_test.go
@@ -33,8 +33,9 @@ func once(newFrontEnd func() lib.Reactor, testId lib.TestId, t *testing.T) (lib.
 	qs := lib.LoadTest(testId)
 	lib.SetSeed(lib.Seed{4})
 	log.Printf("Loaded test of size: %d\n", qs.QueueSize)
-	lib.Register(eventLog, testId)
+	lib.Register(testId)
 	runId := lib.CreateRun(testId)
+	eventLog.RunId = &runId
 	lib.Run()
 	log.Printf("Finished run id: %d\n", runId.RunId)
 	lib.Teardown(&srv)


### PR DESCRIPTION
The initial events added was just for some profiling, but they affect
performance too much to be useful so we remove them.