### PR TITLE
feat(executor+scheduler): Add MetaInfo for each execution step

### DIFF
--- a/src/executor/heap_trace.go
+++ b/src/executor/heap_trace.go
@@ -26,20 +26,7 @@ func jsonDiff(original []byte, modified []byte) []byte {
 	return diff
 }
 
-func appendHeapTrace(db *sql.DB, testId lib.TestId, component string, diff []byte, at time.Time) {
-	var runId lib.RunId
-	{
-		stmt, err := db.Prepare("SELECT MAX(id) FROM run WHERE test_id = ?")
-		if err != nil {
-			panic(err)
-		}
-		defer stmt.Close()
-
-		if err := stmt.QueryRow(testId.TestId).Scan(&runId.RunId); err != nil {
-			panic(err)
-		}
-	}
-
+func appendHeapTrace(db *sql.DB, testId lib.TestId, runId lib.RunId, component string, diff []byte, at time.Time) {
 	stmt, err := db.Prepare(`INSERT INTO heap_trace(test_id, run_id, id, component, heap, at)
                                 VALUES(?, ?,
                                   (SELECT IFNULL(MAX(id), -1) + 1 FROM heap_trace

--- a/src/lib/lib.go
+++ b/src/lib/lib.go
@@ -25,11 +25,18 @@ type Marshaler interface {
 // ---------------------------------------------------------------------
 // Types
 
+type MetaInfo struct {
+	TestId      TestId `json:"test-id"`
+	RunId       RunId  `json:"run-id"`
+	LogicalTime int    `json:"logical-time"`
+}
+
 type ScheduledEvent struct {
 	At    time.Time `json:"at"`
 	From  string    `json:"from"`
 	To    string    `json:"to"`
 	Event InEvent   `json:"event"`
+	Meta  MetaInfo  `json:"meta"`
 }
 
 type InEvent interface{ InEvent() }

--- a/src/lib/scheduler.go
+++ b/src/lib/scheduler.go
@@ -3,11 +3,25 @@ package lib
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 )
 
 type RunId struct {
-	RunId int `json:"run-id"`
+	RunId int
+}
+
+func (runId *RunId) UnmarshalJSON(b []byte) error {
+	var i int
+	if err := json.Unmarshal(b, &i); err != nil {
+		return err
+	}
+	runId.RunId = i
+	return nil
+}
+
+func (runId RunId) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Itoa(runId.RunId)), nil
 }
 
 type QueueSize struct {
@@ -20,7 +34,9 @@ type Seed struct {
 
 func LoadTest(testId TestId) QueueSize {
 	var queueSize QueueSize
-	PostParse("load-test!", testId, &queueSize)
+	PostParse("load-test!", struct {
+		TestId TestId `json:"test-id"`
+	}{testId}, &queueSize)
 	return queueSize
 }
 
@@ -39,9 +55,13 @@ func SetSeed(seed Seed) {
 }
 
 func CreateRun(testId TestId) RunId {
-	var runId RunId
-	PostParse("create-run!", testId, &runId)
-	return runId
+	var runId struct {
+		RunId RunId `json:"run-id"`
+	}
+	PostParse("create-run!", struct {
+		TestId TestId `json:"test-id"`
+	}{testId}, &runId)
+	return runId.RunId
 }
 
 func InjectFaults(faults Faults) {

--- a/src/lib/util.go
+++ b/src/lib/util.go
@@ -14,7 +14,20 @@ import (
 )
 
 type TestId struct {
-	TestId int `json:"test-id"`
+	TestId int
+}
+
+func (testId *TestId) UnmarshalJSON(b []byte) error {
+	var i int
+	if err := json.Unmarshal(b, &i); err != nil {
+		return err
+	}
+	testId.TestId = i
+	return nil
+}
+
+func (testId TestId) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Itoa(testId.TestId)), nil
 }
 
 const schedulerUrl string = "http://localhost:3000"

--- a/src/scheduler/src/scheduler/pure.clj
+++ b/src/scheduler/src/scheduler/pure.clj
@@ -222,11 +222,14 @@
                                        :error-cannot-execute-in-this-state))))
           ;; TODO(stevan): handle case when executor-id doesn't exist... Perhaps
           ;; this should be checked when commands are enqueued?
+          meta {:test-id (:test-id data')
+                :run-id (:run-id data')
+                :logical-time (:logical-clock data')}
           executor-id (get (:topology data') (:to entry))]
       (assert executor-id (str "Target `" (:to entry) "' isn't in topology."))
       [data' {:url executor-id
               :timestamp (:at entry)
-              :body entry
+              :body (assoc entry :meta meta)
               :drop? (cond
                        (should-drop? data' entry) :drop
                        entry-from-client-with-current-request :delay

--- a/src/sut/broadcast/broadcast_test.go
+++ b/src/sut/broadcast/broadcast_test.go
@@ -24,7 +24,7 @@ func once(round Round, testId lib.TestId, t *testing.T) (lib.RunId, bool) {
 	}
 	var srv http.Server
 	lib.Setup(func() {
-		executor.Deploy(&srv, testId, eventLog, topology, marshaler)
+		executor.Deploy(&srv, eventLog, topology, marshaler)
 	})
 	qs := lib.LoadTest(testId)
 	log.Printf("Loaded test of size: %d\n", qs.QueueSize)

--- a/src/sut/register/example_test.go
+++ b/src/sut/register/example_test.go
@@ -28,7 +28,7 @@ func once(newFrontEnd func() lib.Reactor, testId lib.TestId, t *testing.T) (lib.
 	}
 	var srv http.Server
 	lib.Setup(func() {
-		executor.Deploy(&srv, testId, eventLog, topology, marshaler)
+		executor.Deploy(&srv, eventLog, topology, marshaler)
 	})
 	qs := lib.LoadTest(testId)
 	lib.SetSeed(lib.Seed{4})


### PR DESCRIPTION
When Scheduler sends information to executor (Event, Timer) it now
also has a field in the JSON with meta-information. This meta-information
currently contains:

```
{"test-id": <current-test-id>,
 "run-id": <current-run-id>,
 "logical-time": <current-logical-time>}
```

This information should not be sent to the SUT, but only used by the executor
when creating events for the event-log, to tag the appropriate meta information.

This will allow further refactorings of the executor to not have to know the
TestId, RunId. And should enable the executor in the future to be able to
send `Info` events in a straight-forward way.

This commit also changes the default way we (un)marshal TestId and RunId to/from
JSON. It now only uses the underlying number directly, and in the few cases we want
to have a wrapper object, we have to make such a wrapper ourselves.