### PR TITLE
refactor(checker): Use the new NetworkTrace and introduce jepsen_hist…

### DIFF
--- a/src/checker/src/checker/db.clj
+++ b/src/checker/src/checker/db.clj
@@ -77,10 +77,9 @@
   (apply shell/sh "sqlite3" (db) args))
 
 (defn parse
-  [test-id run-id id kind event args process]
+  [test-id run-id kind event args process]
   {:test-id (edn/read-string test-id)
    :run-id  (edn/read-string run-id)
-   :id      (edn/read-string id)
    :kind    kind
    :event   event
    :args    (json/read args)
@@ -88,7 +87,7 @@
 
 (defn get-history
   [model test-id run-id]
-  (let [out (query (str "SELECT * FROM history where test_id = "
+  (let [out (query (str "SELECT * FROM jepsen_history where test_id = "
                         test-id " AND run_id = " run-id))]
     (when (not= 0 (:exit out))
       (println out))
@@ -98,6 +97,7 @@
            str/split-lines
            (map #(str/split % #"\|"))
            (map (partial apply parse))
+           (map-indexed (fn [ix x] (assoc x :index ix)))
            (reduce (partial rewrite model) [{} []])
            second)
       (catch Exception e

--- a/src/db/migrations/1611060819_add_execution_step_view.sql
+++ b/src/db/migrations/1611060819_add_execution_step_view.sql
@@ -1,5 +1,4 @@
 -- +migrate Up
-
 CREATE VIEW IF NOT EXISTS execution_step AS
   SELECT
     json_extract(meta, '$.test-id') as test_id,

--- a/src/db/migrations/1611225124_add_history_view.sql
+++ b/src/db/migrations/1611225124_add_history_view.sql
@@ -1,0 +1,18 @@
+-- +migrate Up
+CREATE VIEW IF NOT EXISTS jepsen_history AS
+  SELECT
+    json_extract(meta, '$.test-id') as test_id,
+    json_extract(meta, '$.run-id') as run_id,
+    json_extract(data, '$.jepsen-type') as kind,
+    json_extract(data, '$.message') as event,
+    json_extract(data, '$.args') as args,
+    json_extract(data, '$.jepsen-process') as process
+    FROM event_log
+   WHERE event like 'NetworkTrace'
+     AND json_extract(data, '$.jepsen-type') IS NOT NULL;
+
+DROP TABLE IF EXISTS history;
+
+-- +migrate Down
+DROP VIEW IF EXISTS jepsen_history;
+CREATE TABLE IF NOT EXISTS history (rowid INTEGER PRIMARY KEY) WITHOUT ROWID;

--- a/src/scheduler/src/scheduler/db.clj
+++ b/src/scheduler/src/scheduler/db.clj
@@ -100,11 +100,6 @@
 ;; Remove this when we no longer use the old events
 (defn append-old-network-history-events!
   [test-id run-id data]
-  (when (:jepsen-type data)
-    (let ;; The args don't is only using the `:response` field if it was a
-         ;; response in the history..
-        [args (if (= (:jepsen-type data) :ok) (:response (:args data)) (:args data))]
-      (append-history! test-id run-id (:jepsen-type data) (:message data) (json/write args) (:jepsen-process data))))
   (append-trace! test-id run-id (:message data) (json/write (:args data)) (:kind data) (:from data) (:to data) (:sent-logical-time data) (:recv-logical-time data) (:dropped data)))
 
 (defn append-network-trace!

--- a/src/scheduler/src/scheduler/pure.clj
+++ b/src/scheduler/src/scheduler/pure.clj
@@ -430,7 +430,7 @@
                       (db/append-network-trace! (:test-id data)
                                                 (:run-id data)
                                                 {:message (:event client-response)
-                                                 :args (:args client-response)
+                                                 :args (:response (:args client-response))
                                                  :from (:from client-response)
                                                  :to (:to client-response)
                                                  :kind "ok" ;; ??


### PR DESCRIPTION
…ory view

This commit introduces the `jepsen_history` view that is used instead of the old
`history` table by the checker. This also required a small change to the
scheduler when it emits the `NetworkTrace` event for messages that are sent back
to the client. There was some special code to remove one layer of `response`
field from the `args`. Now this stripping is happening in the entire event,
rather than just do it for the `history` only. Less special casing.

Now nothing depends on the `history` table and is therefore removed.