### PR TITLE
feat(scheduler): add new create-run-event! endpoint in Scheduler

### DIFF
--- a/src/scheduler/src/scheduler/pure.clj
+++ b/src/scheduler/src/scheduler/pure.clj
@@ -810,6 +810,29 @@
   [(update data :faults (fn [fs] (apply conj fs (:faults faults))))
    {:ok "added faults"}])
 
+(s/def ::create-run-event
+  (s/keys :req-un
+          [::test-id
+           ::seed
+           ::faults
+           ;; The following fields can in the event also be integer rather than just double
+           ;; in the data field they will always be double though.
+           ;; ::tick-frequency
+           ;; ::min-time-ns
+           ;; ::max-time-ns
+           ]))
+
+(>defn create-run-event!
+  [data create-run-event]
+  [::data ::create-run-event => (s/tuple ::data (s/keys :req-un [::run-id]))]
+  (let [[data _] (set-seed! data {:new-seed (:seed create-run-event)})
+        [data run-id] (create-run! data create-run-event)
+        [data _] (inject-faults! data create-run-event)
+        [data _] (set-tick-frequency! data {:new-tick-frequency (:tick-frequency create-run-event)})
+        [data _] (set-min-time! data {:new-min-time-ns (:min-time-ns create-run-event)})
+        [data _] (set-max-time! data {:new-max-time-ns (:max-time-ns create-run-event)})]
+    [data run-id]))
+
 ;; Since the version is a constant GraalVM will evaluate it at compile-time, and
 ;; it will stay fixed independent of run-time values of the environment
 ;; variable.

--- a/src/sut/broadcast/broadcast_test.go
+++ b/src/sut/broadcast/broadcast_test.go
@@ -52,7 +52,7 @@ func many(round Round, t *testing.T) {
 		lib.Reset()
 		maxTime := time.Duration(5) * time.Second
 		runEvent := lib.CreateRunEvent{
-			Seed:          lib.Seed{1},
+			Seed:          lib.Seed(1),
 			Faults:        lib.Faults{faults},
 			TickFrequency: tickFrequency,
 			MaxTimeNs:     maxTime,

--- a/src/sut/register/example_test.go
+++ b/src/sut/register/example_test.go
@@ -72,7 +72,7 @@ func testRegisterWithFrontEnd(newFrontEnd func() lib.Reactor, tickFrequency floa
 	for {
 		lib.Reset()
 		runEvent := lib.CreateRunEvent{
-			Seed:          lib.Seed{4},
+			Seed:          lib.Seed(4),
 			Faults:        lib.Faults{faults},
 			TickFrequency: tickFrequency,
 			MinTimeNs:     0,


### PR DESCRIPTION
This endpoint will create a run, and set all the settings in one go, this is so
we in the future can have a CreateRun event in the event_log with all the
settings.

This endpoint should also be able to create the new event which should be able
to deprecate some older tables (such as `run` and `faults`, though `faults` will
need yet another event).