### PR TITLE
refactor(scheduler): Remove run table

### DIFF
--- a/src/db/migrations/1611828200_remove_run_table.sql
+++ b/src/db/migrations/1611828200_remove_run_table.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+DROP TABLE IF EXISTS run;
+
+-- +migrate Down
+CREATE TABLE IF NOT EXISTS run (rowid INTEGER PRIMARY KEY) WITHOUT ROWID;

--- a/src/lib/scheduler.go
+++ b/src/lib/scheduler.go
@@ -91,7 +91,7 @@ func CreateRun(testId TestId, event CreateRunEvent) RunId {
 	var runId struct {
 		RunId RunId `json:"run-id"`
 	}
-	PostParse("create-run-event!", struct {
+	PostParse("create-run!", struct {
 		TestId        TestId           `json:"test-id"`
 		Seed          Seed             `json:"seed"`
 		Faults        []SchedulerFault `json:"faults"`

--- a/src/scheduler/src/scheduler/db.clj
+++ b/src/scheduler/src/scheduler/db.clj
@@ -35,16 +35,11 @@
                   (update :at time/instant)
                   (update :args json/read)))))
 
-(defn create-run!
-  [test-id seed]
+(defn next-run-id!
+  [test-id]
   (jdbc/execute-one!
    ds
-   ["INSERT INTO run (test_id, id, seed)
-     VALUES (?, (SELECT IFNULL(MAX(id), -1) + 1 FROM run WHERE test_id = ?), ?)"
-    test-id test-id seed])
-  (jdbc/execute-one!
-   ds
-   ["SELECT MAX(id) as `run-id` FROM run WHERE test_id = ?" test-id]
+   ["SELECT IFNULL(MAX(run_id), -1) + 1 as `run-id` FROM run_info WHERE test_id = ?" test-id]
    {:return-keys true :builder-fn rs/as-unqualified-lower-maps}))
 
 (comment


### PR DESCRIPTION
The run table is now gone, all replaced by the `CreateRun` event! The scheduler
now also no longer exposes ways to set seed, tick-frequncy, min/max-time or
faults other than when creating a run.