### PR TITLE
reactor: Use CreateTest event

### DIFF
--- a/src/db/migrations/1611834879_create_test_event.sql
+++ b/src/db/migrations/1611834879_create_test_event.sql
@@ -1,0 +1,20 @@
+-- +migrate Up
+CREATE VIEW IF NOT EXISTS test_info AS
+  SELECT
+    json_extract(meta, '$.test-id') as test_id,
+    json_extract(data, '$.agenda') as agenda,
+    json_extract(data, '$.deployment') as deployment,
+    at as created_time
+    FROM event_log
+   WHERE event like 'CreateTest';
+
+DROP TABLE IF EXISTS deployment;
+DROP TABLE IF EXISTS agenda;
+DROP TABLE IF EXISTS test;
+
+-- +migrate Down
+DROP VIEW IF EXISTS test_info;
+
+CREATE TABLE IF NOT EXISTS test (rowid INTEGER PRIMARY KEY) WITHOUT ROWID;
+CREATE TABLE IF NOT EXISTS agenda (rowid INTEGER PRIMARY KEY) WITHOUT ROWID;
+CREATE TABLE IF NOT EXISTS deployment (rowid INTEGER PRIMARY KEY) WITHOUT ROWID;

--- a/src/debugger/internal/debugger.go
+++ b/src/debugger/internal/debugger.go
@@ -22,10 +22,20 @@ type HeapDiff struct {
 }
 
 func GetInitHeap(testId lib.TestId) []HeapDiff {
-	query := fmt.Sprintf(`SELECT component,args
-                              FROM deployment
-                              WHERE test_id = %d`, testId.TestId)
-	return helper(query)
+	deploys, err := lib.DeploymentInfoForTest(testId)
+	if err != nil {
+		panic(err)
+	}
+
+	diffs := make([]HeapDiff, 0, len(deploys))
+	for _, dep := range deploys {
+		diffs = append(diffs, HeapDiff{
+			Reactor: dep.Reactor,
+			Diff:    dep.Args,
+		})
+	}
+
+	return diffs
 }
 
 func GetHeapTrace(testId lib.TestId, runId lib.RunId) []HeapDiff {

--- a/src/generator/detsys-generator.sh
+++ b/src/generator/detsys-generator.sh
@@ -8,27 +8,34 @@ TEST="$1"
 DETSYS_DB=${DETSYS_DB:-"${HOME}/.detsys.db"}
 
 # Create test.
-sqlite3 "${DETSYS_DB}" "INSERT INTO test DEFAULT VALUES"
-TEST_ID=$(sqlite3 "${DETSYS_DB}" "SELECT max(id) from test")
+TEST_ID=$(sqlite3 "${DETSYS_DB}" "SELECT IFNULL(max(test_id),-1)+1 from test_info")
+
+META=''
+DATA=''
 
 if [ "${TEST}" == "register" ]; then
-  sqlite3 "${DETSYS_DB}" <<EOF
-INSERT INTO agenda (test_id, id, kind, event, args, \`from\`, \`to\`, at)
-VALUES
-  (${TEST_ID}, 0, "invoke", "write", '{"value": 1}', "client:0", "frontend", "1970-01-01T00:00:00Z"),
-  (${TEST_ID}, 1, "invoke", "read",  "{}",           "client:0", "frontend", "1970-01-01T00:00:10Z");
-INSERT INTO deployment VALUES(${TEST_ID}, "frontend", "frontend", '{"inFlight":{},"inFlightSessionToClient":{},"nextSessionId":0}');
-INSERT INTO deployment VALUES(${TEST_ID}, "register1", "register", '{"value":[]}');
-INSERT INTO deployment VALUES(${TEST_ID}, "register2", "register", '{"value":[]}');
-EOF
+    META=$(cat <<END_META
+{"component": "detsys-generator", "test-id": ${TEST_ID}}
+END_META
+        )
+    DATA=$(cat <<END_DATA
+ {"agenda":[{"kind": "invoke", "event": "write", "args": {"value": 1}, "from": "client:0", "to": "frontend", "at": "1970-01-01T00:00:00Z"}, {"kind": "invoke", "event": "read", "args": {}, "from": "client:0", "to": "frontend", "at": "1970-01-01T00:00:10Z"}], "deployment": [{"reactor": "frontend", "type": "frontend", "args": {"inFlight":{},"inFlightSessionToClient":{},"nextSessionId":0}}, {"reactor": "register1", "type": "register", "args": {"value":[]}}, {"reactor": "register2", "type": "register", "args": {"value":[]}}]}
+END_DATA
+        )
 elif [ "${TEST}" == "broadcast" ]; then
-    sqlite3 "${DETSYS_DB}" <<EOF
-INSERT INTO deployment VALUES(${TEST_ID}, "A", "node", '{"log":"Hello world!","neighbours":{}}');
-INSERT INTO deployment VALUES(${TEST_ID}, "B", "node", '{"log":"","neighbours":{}}');
-INSERT INTO deployment VALUES(${TEST_ID}, "C", "node", '{"log":"","neighbours":{}}');
-EOF
+    META=$(cat <<END_META
+{"component": "detsys-generator", "test-id": ${TEST_ID}}
+END_META
+        )
+    DATA=$(cat <<END_DATA
+{"agenda":[], "deployment": [{"reactor": "A", "type": "node", "args": {"log":"Hello world!","neighbours":{}}} , {"reactor": "B", "type": "node", "args": {"log":"","neighbours":{}}} , {"reactor": "C", "type": "node", "args": {"log":"","neighbours":{}}}]}
+END_DATA
+        )
 fi
 
+sqlite3 "${DETSYS_DB}" <<EOF
+INSERT INTO event_log(event, meta,data) VALUES("CreateTest", '${META}', '${DATA}')
+EOF
 echo "${TEST_ID}"
 
 popd > /dev/null

--- a/src/lib/BUILD.bazel
+++ b/src/lib/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "lib",
     srcs = [
         "checker.go",
+        "event.go",
         "generator.go",
         "ldfi.go",
         "lib.go",

--- a/src/lib/event.go
+++ b/src/lib/event.go
@@ -1,0 +1,30 @@
+package lib
+
+import (
+	"database/sql"
+	"encoding/json"
+)
+
+func EmitEvent(db *sql.DB, event string, meta interface{}, data interface{}) {
+	metaBlob, err := json.Marshal(meta)
+	if err != nil {
+		panic(err)
+	}
+
+	dataBlob, err := json.Marshal(data)
+	if err != nil {
+		panic(err)
+	}
+
+	stmt, err := db.Prepare(`INSERT INTO event_log(event, meta, data) VALUES(?,?,?)`)
+	if err != nil {
+		panic(err)
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(event, metaBlob, dataBlob)
+
+	if err != nil {
+		panic(err)
+	}
+}

--- a/src/scheduler/src/scheduler/db.clj
+++ b/src/scheduler/src/scheduler/db.clj
@@ -28,12 +28,12 @@
   [test-id]
   (->> (jdbc/execute!
         ds
-        ["SELECT * FROM agenda WHERE test_id = ? ORDER BY id ASC" test-id]
-        {:return-keys true :builder-fn rs/as-unqualified-lower-maps})
-       (mapv #(-> %
-                  (dissoc :id :test_id)
-                  (update :at time/instant)
-                  (update :args json/read)))))
+        ["SELECT agenda FROM test_info WHERE test_id = ?" test-id]
+        {:builder-fn rs/as-unqualified-lower-maps})
+       first ;; we should only have one test for the test_id..
+       :agenda
+       json/read
+       (mapv #(update % :at time/instant))))
 
 (defn next-run-id!
   [test-id]


### PR DESCRIPTION
The final push to make everything that goes to the db be an event to the
event_log.

This commit creates the `CreateTest` event, which contains the agenda and the
deployment. There is now also an `test_info` view that will contain the agenda
and deployment as columns (the data is still in json). This means that we no
longer use the `agenda`, `deployment` or `test` tables.

Noticeable renamings:
* in deployment we now call the reactors `reactor` instead of `component`.