### PR TITLE
feat(db): CHECK constraint on json columns

### DIFF
--- a/src/db/migrations/0_create_event_log.sql
+++ b/src/db/migrations/0_create_event_log.sql
@@ -3,8 +3,8 @@
 CREATE TABLE IF NOT EXISTS event_log (
 id           INTEGER  PRIMARY KEY,
 event        TEXT     NOT NULL,
-meta         JSON     NOT NULL,
-data         JSON     NOT NULL,
+meta         JSON     NOT NULL CHECK(json_valid(meta)),
+data         JSON     NOT NULL CHECK(json_valid(data)),
 at           DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')));
 
 -- +migrate Down


### PR DESCRIPTION
The event_log now have CHECK constraints that check that the `meta` and `data`
fields are valid json.