### PR TITLE
bug(lib): Non-determ when specifing the to-fields

### DIFF
--- a/src/lib/lib.go
+++ b/src/lib/lib.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"sort"
 	"time"
 )
 
@@ -100,6 +101,7 @@ func Singleton(to Receiver) []Receiver {
 }
 
 func Set(to ...Receiver) []Receiver {
+	sort.Strings(to)
 	return to
 }
 

--- a/src/sut/broadcast/broadcast_test.go
+++ b/src/sut/broadcast/broadcast_test.go
@@ -28,7 +28,7 @@ func once(round Round, testId lib.TestId, runEvent lib.CreateRunEvent, t *testin
 	runId := lib.CreateRun(testId, runEvent)
 	log.Printf("Created run id: %v", runId)
 	lib.Run()
-	log.Printf("Finished run id: %d\n", runId.RunId)
+	log.Printf("Finished run id: %d %d\n", testId.TestId, runId.RunId)
 	lib.Teardown(&srv)
 	log.Printf("Checking\n")
 	nodeB := topology.Reactor("B").(*Node)


### PR DESCRIPTION
The broadcast example is sometimes non-determ when running since it will have
the to field in unspecified order (since they come from a map).

We really shouldn't use a `map` in the sut examples unless we make sure to make
it deterministic.