### PR TITLE
perf(ldfi): Increase performance of ldfi

### DIFF
--- a/src/ldfi/cabal.project
+++ b/src/ldfi/cabal.project
@@ -1,6 +1,6 @@
 packages: .
 
-with-compiler: ghc-8.10.3
+with-compiler: ghc-8.10.4
 
 reject-unconstrained-dependencies: all
 

--- a/src/ldfi/ldfi.cabal
+++ b/src/ldfi/ldfi.cabal
@@ -32,17 +32,19 @@ library
   -- GHC boot library dependencies:
   -- (https://gitlab.haskell.org/ghc/ghc/-/blob/master/packages)
   build-depends:
-      base              >=4.14 && <4.15
+      base                  >=4.14 && <4.15
     , containers
     , filepath
     , mtl
     , template-haskell
+    , unordered-containers
 
   -- Other dependencies:
   build-depends:
       aeson
     , binary
     , bytestring
+    , hashable
     , QuickCheck
     , sqlite-simple
     , text

--- a/src/ldfi/shell.nix
+++ b/src/ldfi/shell.nix
@@ -1,5 +1,5 @@
 { sources ? import ./../../nix/sources.nix
-, compiler ? "ghc8103"
+, compiler ? "ghc8104"
 }:
 
 (import ./default.nix { inherit sources compiler; }).env

--- a/src/ldfi/src/Ldfi/Solver.hs
+++ b/src/ldfi/src/Ldfi/Solver.hs
@@ -7,8 +7,8 @@ import Ldfi.Prop
 
 -- * Solver
 
-data Solution = NoSolution | Solution (Map String Bool)
+data Solution key = NoSolution | Solution (Map key Bool)
   deriving (Show)
 
-data Solver m = Solver
-  {solve :: Formula -> m Solution}
+data Solver key m = Solver
+  {solve :: FormulaF key -> m (Solution key)}

--- a/src/ldfi/src/Ldfi/Storage.hs
+++ b/src/ldfi/src/Ldfi/Storage.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -7,6 +8,7 @@ import Control.Arrow (second)
 import Control.Exception
 import Data.Aeson (decode)
 import qualified Data.Binary.Builder as BB
+import Data.Hashable (Hashable)
 import Data.List (groupBy, intercalate)
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -16,6 +18,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextE
 import Database.SQLite.Simple
+import GHC.Generics (Generic)
 import qualified Ldfi.Marshal.Faults as MF
 import Ldfi.Traces
 import System.Environment
@@ -29,7 +32,9 @@ type TestId = Int
 type RunId = Int
 
 data Fault = Crash Node Time | Omission Edge Time
-  deriving (Eq, Ord, Read, Show)
+  deriving (Eq, Ord, Read, Show, Generic)
+
+instance Hashable Fault
 
 data Failures = Failures
   { fFaultsFromFailedRuns :: [[Fault]],

--- a/src/ldfi/src/Ldfi/Traces.hs
+++ b/src/ldfi/src/Ldfi/Traces.hs
@@ -1,7 +1,11 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 module Ldfi.Traces where
 
+import Data.Hashable (Hashable)
 import Data.Set (Set)
 import qualified Data.Set as Set
+import GHC.Generics (Generic)
 import GHC.Natural
 
 ------------------------------------------------------------------------
@@ -16,7 +20,9 @@ data Event = Event
     to :: Node,
     recv :: Time
   }
-  deriving (Eq, Ord, Read, Show)
+  deriving (Eq, Ord, Read, Show, Generic)
+
+instance Hashable Event
 
 type Node = String
 


### PR DESCRIPTION
Changes:
* Use Hashmap instead of `Map String AST` for remembering the Variables of z3.
Furthermore rather than being a map of the Show of the variable, we keep it as
LDFIVar.
* The SAT variables are generated on demand, rather than all up-front.
* Don't do a simplification (i.e call `simplify`) of the ldfi formuala.
* Don't recompute Set.toList when uneccesarry (the set of all faults were often
  used quite often, and when iterated it used Set.toList in different places).
* Remove an uneccessary use of `(!!)` in `z3SolveAll`.