### PR TITLE
eventloop scheduler

### DIFF
--- a/src/scheduler/src/scheduler/pure.clj
+++ b/src/scheduler/src/scheduler/pure.clj
@@ -401,9 +401,6 @@
                   ;; TODO(stevan): go into error state if response body is of form {"error": ...}
                   ;; (if (:error events) true false)
 
-                  ;; TODO(stevan): Change executor to return this json object.
-                  (assert (= (keys events) '(:events :corrId))
-                          (str "execute!: unexpected response body: " events))
                   (log/debug :events events)
 
                   (assert (:run-id data) "execute!: no run-id set...")
@@ -671,8 +668,6 @@
                       :body
                       json/read
                       (update :events expand-events))]
-       (assert (= (keys events) '(:events :corrId))
-               (str "execute!: unexpected response body: " events))
        (doseq [event (:events events)]
          (conj! all-events event))))
    (let [events (->> all-events


### PR DESCRIPTION
- refactor(runtime): use native types instead of `Datatype` in scheduler
- refactor(runtime): try to use native types for db interface
- refactor(runtime): fix native types for db interface
- feat(runtime): make client request for "CreateTest" do db I/O and respond
- fix(runtime): fix bug with put state not being persisted
- feat(runtime): work towards scheduler being able to communicate with executor
- feat(runtime): fix correlation id propagation
- feat(runtime): step through the whole agenda
- refactor(runtime): add comment about arrival times and clean up a bit
- refactor(runtime): add comment about kebab-casing and restore test used for debugging
- fix(runtime): unbreak backwards compat with old scheduler
- refactor(scheduler): remove assert that was causing trouble before above commit
