### PR TITLE
perf(runtime): benchmark a bunch of single ops

### DIFF
--- a/src/runtime-prototype/bench/disruptor/SingleOps.hs
+++ b/src/runtime-prototype/bench/disruptor/SingleOps.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module Main where
+
+import Control.Monad
+import Data.Time
+import Data.Atomics.Counter
+import Data.IORef
+
+import StuntDouble.Histogram
+
+------------------------------------------------------------------------
+
+main :: IO ()
+main = do
+  many "getCurrentTime" (return ()) (const getCurrentTime)
+
+  many "incrCounter1" (newCounter 0) (incrCounter 1)
+
+  many "modifyIORef'" (newIORef (0 :: Int)) (\r -> modifyIORef' r succ)
+
+  many "atomicModifyIORef'"
+    (newIORef (0 :: Int)) (\r -> atomicModifyIORef' r (\n -> ((n + 1), ())))
+
+many :: String -> IO a -> (a -> IO b) -> IO ()
+many name create use = do
+  h <- newHistogram
+  r <- create
+  replicateM 500000 (once h (use r))
+  putStrLn ""
+  putStrLn ""
+  prettyPrintHistogram name h
+
+once :: Histogram -> IO a -> IO ()
+once h io = do
+  start <- getCurrentTime
+  _     <- io
+  end   <- getCurrentTime
+  -- NOTE: diffUTCTime has a precision of 10^-12 s, so by multiplying by 10^9 we
+  -- get milliseconds.
+  void (measure (realToFrac (diffUTCTime end start) * 1_000_000_000) h)

--- a/src/runtime-prototype/stunt-double.cabal
+++ b/src/runtime-prototype/stunt-double.cabal
@@ -179,10 +179,10 @@ benchmark bench-disruptor
   main-is:        Main.hs
   build-depends:
       async
+    , atomic-primops
     , base
     , stunt-double
     , time
-    , atomic-primops
   ghc-options:    -threaded -eventlog -rtsopts -with-rtsopts=-N
   default-language: Haskell2010
 
@@ -194,6 +194,18 @@ benchmark bench-disruptor-tbqueue
       async
     , base
     , stm
+    , time
+  ghc-options:    -threaded -eventlog -rtsopts -with-rtsopts=-N
+  default-language: Haskell2010
+
+benchmark bench-disruptor-singleops
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: bench/disruptor
+  main-is:        SingleOps.hs
+  build-depends:
+      atomic-primops
+    , base
+    , stunt-double
     , time
   ghc-options:    -threaded -eventlog -rtsopts -with-rtsopts=-N
   default-language: Haskell2010


### PR DESCRIPTION
```
getCurrentTime:
min       med       90        99        99.9      99.99     max       count     sum
69.81     101.51    129.32    161.39    224.88    213201.99 6137940.60500000.00 106731533.00

incrCounter1:
min       med       90        99        99.9      99.99     max       count     sum
39.04     55.83     67.72     108.95    159.77    206900.89 1867291.35500000.00 57647686.00

modifyIORef':
min       med       90        99        99.9      99.99     max       count     sum
39.85     58.15     71.97     106.77    171.43    198788.15 265666.29 500000.00 51555250.00

atomicModifyIORef':
min       med       90        99        99.9      99.99     max       count     sum
58.15     77.26     100.49    140.17    193.42    208980.29 6261935.25500000.00 77499636.0
```