### PR TITLE
eventloop scheduler

### DIFF
--- a/src/runtime-prototype/bench/disruptor/Main.hs
+++ b/src/runtime-prototype/bench/disruptor/Main.hs
@@ -23,7 +23,7 @@ main = do
   let ringBufferCapacity = 1024 * 64
   rb <- newRingBuffer SingleProducer ringBufferCapacity
   histo <- newHistogram
-  transactions <- newCounter (0 :: Int)
+  transactions <- newCounter 0
 
   let production () = do
         {-# SCC "transactions+1" #-} incrCounter_ 1 transactions

--- a/src/runtime-prototype/src/Disruptor.hs
+++ b/src/runtime-prototype/src/Disruptor.hs
@@ -56,22 +56,22 @@ data RingBuffer e = RingBuffer
   {
   -- | Keeps track of if the ring buffer was created for single or multiple
   -- producer(s).
-    rbProducerType :: ProducerType
+    rbProducerType :: !ProducerType
   -- | The capacity, or maximum amount of values, of the ring buffer.
-  , rbCapacity :: Int64
+  , rbCapacity :: {-# UNPACK #-} !Int64
   -- | The cursor pointing to the head of the ring buffer.
-  , rbSequenceNumber :: IORef SequenceNumber
+  , rbSequenceNumber :: {-# UNPACK #-} !(IORef SequenceNumber)
   -- | The values of the ring buffer.
-  , rbEvents :: IOVector e
+  , rbEvents :: {-# UNPACK #-} !(IOVector e)
   -- | References to the last consumers' sequence numbers, used in order to
   -- avoid wrapping the buffer and overwriting events that have not been
   -- consumed yet.
-  , rbGatingSequences :: IORef [IORef SequenceNumber]
+  , rbGatingSequences :: {-# UNPACK #-} !(IORef [IORef SequenceNumber])
   -- | Cached value of computing the last consumers' sequence numbers using the
   -- above references.
-  , rbCachedGatingSequence :: IORef SequenceNumber
+  , rbCachedGatingSequence :: {-# UNPACK #-} !(IORef SequenceNumber)
   -- | Used to keep track of what has been published in the multi-producer case.
-  , rbAvailableBuffer :: IOVector Int
+  , rbAvailableBuffer :: {-# UNPACK #-} !(IOVector Int)
   }
 
 newRingBuffer :: ProducerType -> Int -> IO (RingBuffer e)


### PR DESCRIPTION
- feat(runtime): add SPSC test (fails sometimes with appears twice error message)
- fix(runtime): fix SP case by adding nextSequence field to ring-buffer
- feat(runtime): add more logging to understand the MP problem
- refactor(runtime): nextSequence field is actually not needed, thanks Daniel
- fix(runtime): fix MP case by adding setGatingSequences, thanks Daniel
- fix(runtime): remove sleep from read path and fix test
- refactor(runtime): remove old test
- Update src/runtime-prototype/src/Disruptor.hs
- refactor(runtime): simplify SPSC test, thanks Daniel
- bench(runtime): add simple SPSC benchmark
- bench(runtime): add tbqueue variant to benchmark for comparison
- perf(runtime): use writeIORef instead of atomicWriteIORef where possilbe and do some inlining
- perf(runtime): add cost centers and use atomic counter thater than ioref int
- perf(runtime): benchmark a bunch of single ops
- perf(runtime): measure single ops using CPUTime and in nano sec
- perf(runtime): add latency histogram
- feat(runtime): add first draft of SP histogram
- perf(runtime): add a padded variant of atomic counter
- fix(runtime): make incrCounter return the new value, thanks Daniel
- perf(runtime): tweak SP version of histogram
- reactor(runtime): improve comment about atomic counter padding, thanks Daniel
- fix(runtime): fix bug in SP histogram
- fix(runtime): the shiftL trick doesn't work for Int when calculating buckets
- pref(runtime): remove polymorphism from histogram
- perf(runtime): make the tbqueue benchmark also use measureInt_
- perf(runtime): add max concurrent transactions to output
- perf(runtime): unpack and bang all fields in the ring buffer
