### PR TITLE
eventloop scheduler

### DIFF
--- a/src/runtime-prototype/bench/disruptor/Main.hs
+++ b/src/runtime-prototype/bench/disruptor/Main.hs
@@ -2,10 +2,12 @@ module Main where
 
 import Control.Concurrent
 import Control.Concurrent.Async
-import Data.Time
-import Data.IORef
+import Control.Concurrent.MVar
+import Control.Monad
 import Data.Atomics.Counter
+import Data.IORef
 import Data.Int
+import Data.Time
 import Text.Printf
 
 import Disruptor
@@ -15,7 +17,7 @@ import StuntDouble.Histogram.SingleProducer
 ------------------------------------------------------------------------
 
 iTERATIONS :: Int64
-iTERATIONS = 1000 * 1000 * 5
+iTERATIONS = 1000 * 1000 * 50
 
 main :: IO ()
 main = do
@@ -25,43 +27,45 @@ main = do
   rb <- newRingBuffer SingleProducer ringBufferCapacity
   histo <- newHistogram
   transactions <- newCounter 0
+  consumerFinished <- newEmptyMVar
 
-  let production () = do
-        {-# SCC "transactions+1" #-} incrCounter_ 1 transactions
-        return (1 :: Int, ())
-      backPressure () = return ()
-  ep <- newEventProducer rb production backPressure ()
-  let handler _s _n snr _endOfBatch = do
+  let ep = EventProducer (const (go iTERATIONS)) () (error "not used")
+        where
+          go :: Int64 -> IO ()
+          go 0 = return ()
+          go n = do
+            {-# SCC "transactions+1" #-} incrCounter_ 1 transactions
+            mSnr <- tryNext rb
+            case mSnr of
+              Just snr -> do
+                set rb snr (1 :: Int)
+                publish rb snr
+                go (n - 1)
+              Nothing -> go n
+
+  let handler _s _n snr endOfBatch = do
         t' <- {-# SCC "transactions-1" #-} incrCounter (-1) transactions
         measureInt_ t' histo
-        return snr
+        when (endOfBatch && getSequenceNumber snr == iTERATIONS - 1) $
+          putMVar consumerFinished ()
+        return ()
 
-  ec <- newEventConsumer rb handler 0 [] (Sleep 1)
+  ec <- newEventConsumer rb handler () [] (Sleep 1)
   setGatingSequences rb [Exists ec]
 
-  let areWeDoneConsuming = do
-        t <- readIORef (ecSequenceNumber ec)
-        if t >= fromIntegral iTERATIONS - 1
-        then return ()
-        else do
-          threadDelay 10000
-          areWeDoneConsuming
   start <- getCurrentTime
   withEventProducer ep $ \aep ->
-    withEventConsumer ec $ \aec ->
-     withAsync areWeDoneConsuming $ \a -> do
-       wait a
-       shutdownProducer ep
-       wait aep
-       shutdownConsumer ec
-       events <- wait aec
-       end <- getCurrentTime
-       printf "%-25.25s%10d\n"     "Total number of events" (getSequenceNumber events)
-       printf "%-25.25s%10.2f s\n" "Duration" (realToFrac (diffUTCTime end start) :: Double)
-       let throughput = realToFrac events / realToFrac (diffUTCTime end start)
-       printf "%-25.25s%10.2f events/s\n" "Throughput" throughput
-       meanTransactions <- hmean histo
-       printf "%-25.25s%10.2f\n" "Mean concurrent txs" meanTransactions
-       Just maxTransactions <- percentile 100.0 histo
-       printf "%-25.25s%10.2f\n" "Max concurrent txs" maxTransactions
-       printf "%-25.25s%10.2f ns\n" "Latency" ((meanTransactions / throughput) * 1000000)
+    withEventConsumer ec $ \aec -> do
+      () <- takeMVar consumerFinished
+      end <- getCurrentTime
+      cancel aep
+      cancel aec
+      printf "%-25.25s%10d\n"     "Total number of events" iTERATIONS
+      printf "%-25.25s%10.2f s\n" "Duration" (realToFrac (diffUTCTime end start) :: Double)
+      let throughput = realToFrac iTERATIONS / realToFrac (diffUTCTime end start)
+      printf "%-25.25s%10.2f events/s\n" "Throughput" throughput
+      meanTransactions <- hmean histo
+      printf "%-25.25s%10.2f\n" "Mean concurrent txs" meanTransactions
+      Just maxTransactions <- percentile 100.0 histo
+      printf "%-25.25s%10.2f\n" "Max concurrent txs" maxTransactions
+      printf "%-25.25s%10.2f ns\n" "Latency" ((meanTransactions / throughput) * 1000000)

--- a/src/runtime-prototype/bench/disruptor/SP.hs
+++ b/src/runtime-prototype/bench/disruptor/SP.hs
@@ -2,15 +2,17 @@ module Main where
 
 import Control.Concurrent
 import Control.Concurrent.Async
-import Data.Time
-import Data.IORef
+import Control.Concurrent.MVar
+import Control.Monad
 import Data.Atomics.Counter
+import Data.IORef
 import Data.Int
+import Data.Time
 import Text.Printf
 
-import Disruptor.RingBuffer.SingleProducer
 import Disruptor.Consumer
 import Disruptor.Producer
+import Disruptor.RingBuffer.SingleProducer
 import Disruptor.SequenceNumber
 import StuntDouble.Histogram.SingleProducer
 
@@ -27,43 +29,46 @@ main = do
   rb <- newRingBuffer ringBufferCapacity
   histo <- newHistogram
   transactions <- newCounter 0
+  consumerFinished <- newEmptyMVar
 
-  let production () = do
-        {-# SCC "transactions+1" #-} incrCounter_ 1 transactions
-        return (1 :: Int, ())
-      backPressure () = return ()
-  ep <- newEventProducer rb production backPressure ()
-  let handler _s _n snr _endOfBatch = do
+  let ep = EventProducer (const (go iTERATIONS)) ()
+        where
+          go :: Int64 -> IO ()
+          go 0 = return ()
+          go n = do
+            {-# SCC "transactions+1" #-} incrCounter_ 1 transactions
+            mSnr <- tryNext rb
+            case mSnr of
+              Just snr -> do
+                set rb snr (1 :: Int)
+                publish rb snr
+                go (n - 1)
+              Nothing -> go n
+
+  let handler _s _n snr endOfBatch = do
         t' <- {-# SCC "transactions-1" #-} incrCounter (-1) transactions
         measureInt_ t' histo
-        return snr
+        when (endOfBatch && getSequenceNumber snr == iTERATIONS - 1) $
+          putMVar consumerFinished ()
+        return ()
 
-  ec <- newEventConsumer rb handler 0 [] (Sleep 1)
+  ec <- newEventConsumer rb handler () [] (Sleep 1)
   setGatingSequences rb [ecSequenceNumber ec]
 
-  let areWeDoneConsuming = do
-        t <- readIORef (ecSequenceNumber ec)
-        if t >= fromIntegral iTERATIONS - 1
-        then return ()
-        else do
-          threadDelay 10000
-          areWeDoneConsuming
   start <- getCurrentTime
   withEventProducer ep $ \aep ->
-    withEventConsumer ec $ \aec ->
-     withAsync areWeDoneConsuming $ \a -> do
-       wait a
-       shutdownProducer ep
-       wait aep
-       shutdownConsumer ec
-       events <- wait aec
-       end <- getCurrentTime
-       printf "%-25.25s%10d\n"     "Total number of events" (getSequenceNumber events)
-       printf "%-25.25s%10.2f s\n" "Duration" (realToFrac (diffUTCTime end start) :: Double)
-       let throughput = realToFrac events / realToFrac (diffUTCTime end start)
-       printf "%-25.25s%10.2f events/s\n" "Throughput" throughput
-       meanTransactions <- hmean histo
-       printf "%-25.25s%10.2f\n" "Mean concurrent txs" meanTransactions
-       Just maxTransactions <- percentile 100.0 histo
-       printf "%-25.25s%10.2f\n" "Max concurrent txs" maxTransactions
-       printf "%-25.25s%10.2f ns\n" "Latency" ((meanTransactions / throughput) * 1000000)
+    withEventConsumer ec $ \aec -> do
+      () <- takeMVar consumerFinished
+      end <- getCurrentTime
+      cancel aep
+      cancel aec
+      end <- getCurrentTime
+      printf "%-25.25s%10d\n"     "Total number of events" iTERATIONS
+      printf "%-25.25s%10.2f s\n" "Duration" (realToFrac (diffUTCTime end start) :: Double)
+      let throughput = realToFrac iTERATIONS / realToFrac (diffUTCTime end start)
+      printf "%-25.25s%10.2f events/s\n" "Throughput" throughput
+      meanTransactions <- hmean histo
+      printf "%-25.25s%10.2f\n" "Mean concurrent txs" meanTransactions
+      Just maxTransactions <- percentile 100.0 histo
+      printf "%-25.25s%10.2f\n" "Max concurrent txs" maxTransactions
+      printf "%-25.25s%10.2f ns\n" "Latency" ((meanTransactions / throughput) * 1000000)

--- a/src/runtime-prototype/bench/disruptor/TBQueue.hs
+++ b/src/runtime-prototype/bench/disruptor/TBQueue.hs
@@ -13,7 +13,7 @@ import StuntDouble.Histogram.SingleProducer
 ------------------------------------------------------------------------
 
 iTERATIONS :: Int64
-iTERATIONS = 1000 * 1000 * 50
+iTERATIONS = 1000 * 1000 * 5
 
 main :: IO ()
 main = do

--- a/src/runtime-prototype/src/Disruptor.hs
+++ b/src/runtime-prototype/src/Disruptor.hs
@@ -269,6 +269,7 @@ tryNextBatch rb n
         if success
         then return (Just next)
         else mp
+{-# INLINE tryNextBatch #-}
 
 remainingCapacity :: RingBuffer e -> IO Int64
 remainingCapacity rb = do

--- a/src/runtime-prototype/src/Disruptor/Consumer.hs
+++ b/src/runtime-prototype/src/Disruptor/Consumer.hs
@@ -16,7 +16,6 @@ data EventConsumer s = EventConsumer
   { ecSequenceNumber :: IORef SequenceNumber
   , ecWorker         :: s -> IO s
   , ecInitialState   :: s
-  , ecShutdown       :: Shutdown
   }
 
 -- NOTE: The `SequenceNumber` can be used for sharding, e.g. one handler handles
@@ -45,7 +44,6 @@ newEventConsumer :: RingBuffer e -> EventHandler s e -> s -> [SequenceBarrier e]
                  -> WaitStrategy -> IO (EventConsumer s)
 newEventConsumer rb handler s0 barriers (Sleep n) = do
   snrRef <- newIORef (-1)
-  shutdownVar <- newShutdownVar
 
   let go s = {-# SCC go #-} do
         mySnr <- readIORef snrRef
@@ -57,18 +55,12 @@ newEventConsumer rb handler s0 barriers (Sleep n) = do
             -- couple of tries go into a takeMTVar sleep waiting for a producer to
             -- wake us up.
             threadDelay n
-            halt <- isItTimeToShutdown shutdownVar
-            if halt
-            then return s
-            else go s
+            go s -- SPIN
           Just bSnr -> do
             -- XXX: what if handler throws exception? https://youtu.be/eTeWxZvlCZ8?t=2271
             s' <- {-# SCC go' #-} go' (mySnr + 1) bSnr s
             writeIORef snrRef bSnr
-            halt <- isItTimeToShutdown shutdownVar
-            if halt
-            then return s'
-            else go s' -- SPIN
+            go s'
             where
               go' lo hi s | lo >  hi = return s
                           | lo <= hi = do
@@ -76,10 +68,14 @@ newEventConsumer rb handler s0 barriers (Sleep n) = do
                 s' <- {-# SCC handler #-} handler s e lo (lo == hi)
                 go' (lo + 1) hi s'
 
-  return (EventConsumer snrRef go s0 shutdownVar)
+  return (EventConsumer snrRef go s0)
 
 waitFor :: SequenceNumber -> RingBuffer e -> [SequenceBarrier e] -> IO (Maybe SequenceNumber)
-waitFor snr rb [] = waitFor snr rb [RingBufferBarrier rb]
+waitFor snr rb [] = do
+  minSnr <- readIORef (rbCursor rb)
+  if snr < minSnr
+  then return (Just minSnr)
+  else return Nothing
 waitFor snr rb bs = do
   minSnr <- minimum <$> mapM readIORef (map getSequenceNumberRef bs)
   if snr < minSnr
@@ -89,19 +85,4 @@ waitFor snr rb bs = do
     getSequenceNumberRef :: SequenceBarrier e -> IORef SequenceNumber
     getSequenceNumberRef (RingBufferBarrier    rb) = rbCursor rb
     getSequenceNumberRef (EventConsumerBarrier ec) = ecSequenceNumber ec
-
-------------------------------------------------------------------------
-
-newtype Shutdown = Shutdown (TMVar ())
-
-newShutdownVar :: IO Shutdown
-newShutdownVar = Shutdown <$> newEmptyTMVarIO
-
-tellToShutdown :: Shutdown -> IO ()
-tellToShutdown (Shutdown tmvar) = () <$ atomically (tryPutTMVar tmvar ())
-
-shutdownConsumer :: EventConsumer s -> IO ()
-shutdownConsumer = tellToShutdown . ecShutdown
-
-isItTimeToShutdown :: Shutdown -> IO Bool
-isItTimeToShutdown (Shutdown tmvar) = not <$> atomically (isEmptyTMVar tmvar)
+{-# INLINE waitFor #-}

--- a/src/runtime-prototype/src/Disruptor/RingBuffer/SingleProducer.hs
+++ b/src/runtime-prototype/src/Disruptor/RingBuffer/SingleProducer.hs
@@ -128,7 +128,7 @@ nextBatch rb n = assert (n > 0 && fromIntegral n <= capacity rb) $ do
           if wrapPoint > gatingSequence
           then go
           else setCachedGatingSequence rb gatingSequence
-{-# INLINABLE nextBatch #-}
+{-# INLINE nextBatch #-}
 
 -- Try to return the next sequence number to write to. If `Nothing` is returned,
 -- then the last consumer has not yet processed the event we are about to


### PR DESCRIPTION
- feat(runtime): add SPSC test (fails sometimes with appears twice error message)
- fix(runtime): fix SP case by adding nextSequence field to ring-buffer
- feat(runtime): add more logging to understand the MP problem
- refactor(runtime): nextSequence field is actually not needed, thanks Daniel
- fix(runtime): fix MP case by adding setGatingSequences, thanks Daniel
- fix(runtime): remove sleep from read path and fix test
- refactor(runtime): remove old test
- Update src/runtime-prototype/src/Disruptor.hs
- refactor(runtime): simplify SPSC test, thanks Daniel
- bench(runtime): add simple SPSC benchmark
- bench(runtime): add tbqueue variant to benchmark for comparison
- perf(runtime): use writeIORef instead of atomicWriteIORef where possilbe and do some inlining
- perf(runtime): add cost centers and use atomic counter thater than ioref int
- perf(runtime): benchmark a bunch of single ops
- perf(runtime): measure single ops using CPUTime and in nano sec
- perf(runtime): add latency histogram
- feat(runtime): add first draft of SP histogram
- perf(runtime): add a padded variant of atomic counter
- fix(runtime): make incrCounter return the new value, thanks Daniel
- perf(runtime): tweak SP version of histogram
- reactor(runtime): improve comment about atomic counter padding, thanks Daniel
- fix(runtime): fix bug in SP histogram
- fix(runtime): the shiftL trick doesn't work for Int when calculating buckets
- pref(runtime): remove polymorphism from histogram
- perf(runtime): make the tbqueue benchmark also use measureInt_
- perf(runtime): add max concurrent transactions to output
- perf(runtime): unpack and bang all fields in the ring buffer
- perf(runtime): start separating SP from MP ringbuffer
- refactor(runtime): finish standalone MP version of ringbuffer
- refactor(runtime): remove shutdown variable
