### PR TITLE
eventloop scheduler

### DIFF
--- a/src/runtime-prototype/bench/disruptor/MP/Disruptor.hs
+++ b/src/runtime-prototype/bench/disruptor/MP/Disruptor.hs
@@ -28,8 +28,8 @@ main = mpsc setup producer consumer
               set rb snr vALUE_TO_WRITE
               publish rb snr
               go (n - 1)
-            None -> do
-              -- threadDelay sLEEP_TIME
+            None ->
+              -- NOTE: No sleep needed here.
               go n
 
     consumer :: RingBuffer Int -> MVar () -> IO ()

--- a/src/runtime-prototype/benchmark.sh
+++ b/src/runtime-prototype/benchmark.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 # Inspired by: https://sled.rs/perf.html#experimental-design
 
-BENCHMARK_WORKLOAD1="bench-disruptor-sp"
-BENCHMARK_WORKLOAD2="bench-disruptor-sp-tbqueue"
+BENCHMARK_WORKLOAD1="bench-disruptor-mp"
+BENCHMARK_WORKLOAD2="bench-disruptor-mp-unagi-chan"
 BENCHMARK_NUMBER_OF_RUNS=5
 BENCHMARK_GHC_OPTS=("-threaded" "-rtsopts" "-with-rtsopts=-N")
 BENCHMARK_CABAL_BUILD_OPTS=("--disable-profiling"


### PR DESCRIPTION
- perf(runtime): add single op benchmarks for threadDelay and yield
- refactor(runtime): clean up benchmarks a bit more, especially mp cases
- fix(runtime): fix off by one error in test
