### PR TITLE
feat(runtime): Executors can now restart the reactors

### DIFF
--- a/src/executor-event-loop/admin.go
+++ b/src/executor-event-loop/admin.go
@@ -17,6 +17,7 @@ const (
 	AdminQuit = iota
 	AdminDumpLog
 	AdminResetLog
+	AdminResetReactors
 	AdminUnknown
 )
 
@@ -28,9 +29,10 @@ type AdminCommand struct {
 // panic galore if we don't have it
 func parseCommandFromString(command string) AdminCommandType {
 	v, ok := map[string]AdminCommandType{
-		"AdminQuit":     AdminQuit,
-		"AdminDumpLog":  AdminDumpLog,
-		"AdminResetLog": AdminResetLog,
+		"AdminQuit":          AdminQuit,
+		"AdminDumpLog":       AdminDumpLog,
+		"AdminResetLog":      AdminResetLog,
+		"AdminResetReactors": AdminResetReactors,
 	}[command]
 	if !ok {
 		return AdminUnknown

--- a/src/executor-event-loop/eventloop.go
+++ b/src/executor-event-loop/eventloop.go
@@ -77,6 +77,11 @@ func (el *EventLoop) processAdmin(cmd AdminCommand) bool {
 		el.Log = make([]TimestampedLogEntry, 0)
 		cmd.Response("Log reseted\n")
 		return false
+	case AdminResetReactors:
+		fmt.Printf("resetting reactors\n")
+		el.Executor.Reset()
+		cmd.Response("Reactors restarted\n")
+		return false
 	default:
 		fmt.Printf("Unknown admin command: %#v\n", cmd)
 		panic("Unhandled admin command")

--- a/src/executor-event-loop/executor.go
+++ b/src/executor-event-loop/executor.go
@@ -24,17 +24,23 @@ type StepInfo struct {
 type ComponentUpdate = func(component string) StepInfo
 
 type Executor struct {
-	Topology  lib.Topology
-	Marshaler lib.Marshaler
+	Topology      lib.Topology
+	BuildTopology func() lib.Topology
+	Marshaler     lib.Marshaler
 	//Update    ComponentUpdate
 }
 
-func NewExecutor(topology lib.Topology, m lib.Marshaler) *Executor {
+func NewExecutor(buildTopology func() lib.Topology, m lib.Marshaler) *Executor {
 	return &Executor{
-		Topology:  topology,
-		Marshaler: m,
+		Topology:      buildTopology(),
+		BuildTopology: buildTopology,
+		Marshaler:     m,
 		//Update:    cu,
 	}
+}
+
+func (ex Executor) Reset() {
+	ex.Topology = ex.BuildTopology()
 }
 
 func (el Executor) processEnvelope(env Envelope) Message {

--- a/src/sut/register/executor/executorcmd.go
+++ b/src/sut/register/executor/executorcmd.go
@@ -15,11 +15,13 @@ func main() {
 	fmt.Printf("Created admin\n")
 	commandT := executorEL.NewCommandTransport("/tmp/executor.sock")
 	fmt.Printf("Created command transport\n")
-	topology := lib.NewTopology(
-		lib.Item{"frontend", sut.NewFrontEnd()},
-		lib.Item{"register1", sut.NewRegister()},
-		lib.Item{"register2", sut.NewRegister()},
-	)
+	topology := func() lib.Topology {
+		return lib.NewTopology(
+			lib.Item{"frontend", sut.NewFrontEnd()},
+			lib.Item{"register1", sut.NewRegister()},
+			lib.Item{"register2", sut.NewRegister()},
+		)
+	}
 	exe := executorEL.NewExecutor(topology, sut.NewMarshaler())
 	el := executorEL.NewEventLoop(adminI, commandT, exe)
 


### PR DESCRIPTION
A new admin command has been added to restart the reactors. The admin command is
called `AdminResetReactors` and can for example be invoked like this:
```bash
$ echo "AdminResetReactors" | nc -U /tmp/executor-admin.sock
Reactors restarted
```

When creating an executor program, one now have to give a function creating a
topology, rather than just a topology. So when we reset, we just create a new
topology for the executor to run on.