### PR TITLE
feat(runtime): Executor now give a `LogWriter` to all reactors in the…

### DIFF
--- a/src/executor-event-loop/eventloop.go
+++ b/src/executor-event-loop/eventloop.go
@@ -108,7 +108,10 @@ func (el *EventLoop) Run() {
 			me := envelope.Receiver.ToLocal()
 			el.LogicalTime.Merge(envelope.LogicalTime)
 			el.AddToLog(LogResumeContinuation, me, envelope.Message)
-			outgoingMessage := el.Executor.processEnvelope(envelope)
+			outgoingMessage, _ /*rui*/ := el.Executor.processEnvelope(envelope)
+			// TODO we should add rui to the log
+			// el.LogicalTime.Incr()
+			// el.AddToLog()
 			el.LogicalTime.Incr()
 			outgoing := el.toSchedulerEnvelope(envelope.Receiver, outgoingMessage, envelope.CorrelationId)
 			el.AddToLog(LogSend, me, outgoingMessage)

--- a/src/executor-event-loop/logwriter.go
+++ b/src/executor-event-loop/logwriter.go
@@ -1,0 +1,45 @@
+package executorEL
+
+type LogWriter [][]byte
+
+func newLogWriter() *LogWriter {
+	x := LogWriter(make([][]byte, 0, 0))
+	return &x
+}
+
+func (lw *LogWriter) dump() []string {
+	logs := make([]string, 0, len(*lw))
+	for _, l := range *lw {
+		logs = append(logs, string(l))
+	}
+	*lw = LogWriter(make([][]byte, 0, 0))
+	return logs
+}
+
+func (_ *LogWriter) Sync() error {
+	return nil
+}
+
+func (lw *LogWriter) Write(p []byte) (n int, err error) {
+	if len(p) > 0 {
+		// make a copy of the line so that it doesn't get changed later
+		line := make([]byte, len(p))
+		copy(line, p)
+
+		// we remove last byte since it is an newline
+		*lw = append(*lw, line[:len(line)-1])
+	}
+	return len(p), nil
+}
+
+/*
+func (lw LogWriter) AppendToLogger(logger *zap.Logger) *zap.Logger {
+	return logger.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
+		config := zap.NewDevelopmentEncoderConfig()
+		config.TimeKey = ""
+		config.LineEnding = ""
+		dbLogger := zapcore.NewCore(zapcore.NewConsoleEncoder(config), lw, c)
+		return zapcore.NewTee(c, dbLogger)
+	}))
+}
+*/

--- a/src/sut/register/executor/executorcmd.go
+++ b/src/sut/register/executor/executorcmd.go
@@ -8,7 +8,7 @@ import (
 	"github.com/symbiont-io/detsys-testkit/src/sut/register"
 )
 
-func constructor(name string) lib.Reactor {
+func constructor(name string, logbuffer *executorEL.LogWriter) lib.Reactor {
 	switch name {
 	case "frontend":
 		return sut.NewFrontEnd4()


### PR DESCRIPTION
… constructor

This `LogWriter` implements the `io.Writer` interface and also the `Sync()`
interface that are used by the `zap` logging framework (and potentially others).
The executor will make sure that each time a reactor logs, that the log messages
will be correctly associated together with the message the reactor is reacting
to.