### PR TITLE
feat(runtime): Use json serialisation for the event log

### DIFF
--- a/src/executor-event-loop/eventloop.go
+++ b/src/executor-event-loop/eventloop.go
@@ -1,8 +1,8 @@
 package executorEL
 
 import (
+	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 )
 
@@ -65,12 +65,11 @@ func (el *EventLoop) processAdmin(cmd AdminCommand) bool {
 		return true
 	case AdminDumpLog:
 		fmt.Printf("dumping log\n")
-		log := make([]string, 0, len(el.Log))
-		for _, e := range el.Log {
-			log = append(log, e.Serialise())
+		toSend, err := json.Marshal(el.Log)
+		if err != nil {
+			panic(err)
 		}
-		toSend := "Log [" + strings.Join(log, ", ") + "]\n"
-		cmd.Response(toSend)
+		cmd.Response(string(toSend))
 		return false
 	case AdminResetLog:
 		fmt.Printf("resetting log\n")

--- a/src/executor-event-loop/log.go
+++ b/src/executor-event-loop/log.go
@@ -1,8 +1,7 @@
 package executorEL
 
 import (
-	"fmt"
-	"strings"
+	"encoding/json"
 	"time"
 )
 
@@ -14,33 +13,31 @@ const (
 )
 
 type LogEntry struct {
-	LocalRef  LocalRef     `json:"local-ref"`
-	RemoteRef RemoteRef    `json:"remote-ref"`
-	Message   Message      `json:"message"`
-	Direction LogDirection `json:"direction"`
+	LocalRef  LocalRef
+	RemoteRef RemoteRef
+	Message   Message
+	Direction LogDirection
+}
+
+func (le LogEntry) MarshalJSON() ([]byte, error) {
+	var tag string
+	switch le.Direction {
+	case LogSend:
+		tag = "LogSend"
+	case LogResumeContinuation:
+		tag = "LogResumeContinuation"
+	}
+	j, err := json.Marshal(struct {
+		LocalRef  int       `json:"localRef"`
+		RemoteRef RemoteRef `json:"remoteRef"`
+		Message   Message   `json:"message"`
+		Tag       string    `json:"tag"`
+	}{le.LocalRef.Index, le.RemoteRef, le.Message, tag})
+	return j, err
 }
 
 type TimestampedLogEntry struct {
-	LogEntry    LogEntry    `json:"entry"`
-	LogicalTime LogicalTime `json:"logical-time"`
+	LogEntry    LogEntry    `json:"content"`
+	LogicalTime LogicalTime `json:"logicalTime"`
 	Time        time.Time   `json:"time"`
-}
-
-// in the future will probably also take the name of event-loop
-func (tle TimestampedLogEntry) Serialise() string {
-	le := tle.LogEntry
-	em := strings.ReplaceAll(string(le.Message.Message), "\"", "\\\"")
-	lr := fmt.Sprintf("(LocalRef %d)", le.LocalRef.Index)
-	rr := fmt.Sprintf("(RemoteRef {address = %#v, index = %d})", le.RemoteRef.Address, le.RemoteRef.Index)
-	m := fmt.Sprintf("(InternalMessage \"%s\")", em)
-	lt := fmt.Sprintf("(LogicalTime (NodeName \"executor\") %d)", int(tle.LogicalTime))
-	t := fmt.Sprintf("(Time %s)", tle.Time.UTC().Format("2006-01-02 15:04:05.00000 MST"))
-	switch le.Direction {
-	case LogSend:
-		return fmt.Sprintf("Timestamped (LogSend %s %s %s) %s %s", lr, rr, m, lt, t)
-	case LogResumeContinuation:
-		return fmt.Sprintf("Timestamped (LogResumeContinuation %s %s %s) %s %s", rr, lr, m, lt, t)
-	default:
-		panic("Unknown direction in log")
-	}
 }

--- a/src/runtime-prototype/src/StuntDouble/Log.hs
+++ b/src/runtime-prototype/src/StuntDouble/Log.hs
@@ -1,7 +1,31 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module StuntDouble.Log where
 
+import Control.Monad (forM)
+import Data.Aeson
+import qualified Data.Aeson.Text as AesonText
+import Data.Aeson.Encoding
+       ( encodingToLazyByteString
+       , list
+       , pair
+       , pairs
+       , text
+       , unsafeToEncoding
+       )
+import Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.Binary.Builder (fromLazyByteString)
+import Data.Char (toLower)
+import qualified Data.Text.Lazy as Text
+import Data.Traversable (fmapDefault, foldMapDefault)
 import Control.Exception
+import GHC.Generics (Generic)
 
+import StuntDouble.Codec
 import StuntDouble.Message
 import StuntDouble.Reference
 import StuntDouble.Time
@@ -10,18 +34,70 @@ import StuntDouble.LogicalTime
 ------------------------------------------------------------------------
 
 newtype Log = Log [Timestamped LogEntry]
-  deriving (Show, Read)
+  deriving stock (Show, Read)
+  deriving newtype (FromJSON)
 
-data Timestamped a = Timestamped a LogicalTime Time
-  deriving (Show, Read)
+data Timestamped' lt a = Timestamped
+ { tsContent :: a
+ , tsLogicalTime :: lt
+ , tsTime :: Time
+ } deriving stock (Show, Read, Generic)
+type Timestamped = Timestamped' LogicalTime
+
+instance Functor (Timestamped' lt) where
+  fmap = fmapDefault
+
+instance Foldable (Timestamped' lt) where
+  foldMap = foldMapDefault
+
+instance Traversable (Timestamped' lt) where
+  traverse f (Timestamped a b c) = (\x -> Timestamped x b c) <$> f a
+
+tsAesonOptions = defaultOptions
+  { fieldLabelModifier = \s -> case drop (length ("ts" :: String)) s of
+      (x : xs) -> toLower x : xs
+      [] -> error "impossible, unless the field names of `Timestamped` changed"
+  }
+instance (FromJSON lt, FromJSON a) => FromJSON (Timestamped' lt a)
+  where parseJSON = genericParseJSON tsAesonOptions
 
 data TimestampedLogically a = TimestampedLogically a LogicalTimeInt
-  deriving (Show, Read)
+  deriving stock (Show, Read)
 
-data LogEntry
-  = LogSend LocalRef RemoteRef Message
-  | LogResumeContinuation RemoteRef LocalRef Message
-  deriving (Show, Read)
+data LogEntry' msg
+  = LogSend
+    { leLocalRef :: LocalRef
+    , leRemoteRef :: RemoteRef
+    , leMessage :: msg
+    }
+  | LogResumeContinuation
+    { leRemoteRef :: RemoteRef
+    , leLocalRef :: LocalRef
+    , leMessage :: msg
+    }
+  deriving stock (Show, Read, Generic)
+type LogEntry = LogEntry' Message
+
+instance Functor LogEntry' where
+  fmap = fmapDefault
+
+instance Foldable LogEntry' where
+  foldMap = foldMapDefault
+
+instance Traversable LogEntry' where
+  traverse f (LogSend a b c) = (\x -> LogSend a b x) <$> f c
+  traverse f (LogResumeContinuation a b c) = (\x -> LogResumeContinuation a b x) <$> f c
+
+leAesonOptions = defaultOptions
+  { fieldLabelModifier = \s -> case drop (length ("le" :: String)) s of
+      (x : xs) -> toLower x : xs
+      [] -> error "impossible, unless the field names of `LogEntry` changed"
+  , sumEncoding = defaultTaggedObject
+    { tagFieldName = "tag" }
+  }
+
+instance FromJSON m => FromJSON (LogEntry' m)
+  where parseJSON = genericParseJSON leAesonOptions
 
   {-
   = Spawned LocalRef
@@ -53,9 +129,33 @@ appendLog :: LogEntry -> LogicalTime -> Time -> Log -> Log
 appendLog e lt t (Log es) = Log (Timestamped e lt t : es)
 
 -- XXX: Use more efficient data structure to avoid having to reverse.
--- XXX: better serialisation than show...
-getLog :: Log -> String
-getLog (Log es) = show (Log (reverse es))
+-- AdminTransport wants the messages to be `String`, otherwise we could probably skip
+-- some translation here
+getLog :: Codec -> Log -> String
+getLog (Codec enc _) (Log es) =
+  LBS.unpack $ encodingToLazyByteString f
+  where
+    f = flip list (reverse es) $ \(Timestamped x (LogicalTime _ lt) t) -> pairs
+      ( (pair "content" $ pairs
+          ((pair "tag" (case x of
+            LogSend {} -> text "LogSend"
+            LogResumeContinuation{} -> text "LogResumeContinuation")) <>
+          "localRef" .= leLocalRef x <>
+          "remoteRef" .= leRemoteRef x <>
+          (pair "message" (unsafeToEncoding (fromLazyByteString (enc (leMessage x)))))
+          )) <>
+      "logicalTime" .= lt <>
+      "time" .= t
+      )
+
+parseLog :: NodeName -> Codec -> ByteString -> Either String Log
+parseLog nn (Codec _ dec) s = do
+  xs :: [Timestamped' LogicalTimeInt (LogEntry' Value)] <- eitherDecode s
+  xs' <- forM xs $ \t ->
+    forM t $ \le ->
+      forM le $ \m ->
+        dec (encode m)
+  pure . Log $ fmap (\ (Timestamped x lt t) -> Timestamped x (LogicalTime nn lt) t) xs'
 
 -- Assumes the logs are already sorted
 merge :: Log -> Log -> Log

--- a/src/runtime-prototype/src/StuntDouble/Reference.hs
+++ b/src/runtime-prototype/src/StuntDouble/Reference.hs
@@ -10,7 +10,10 @@ import Data.String
 ------------------------------------------------------------------------
 
 newtype LocalRef = LocalRef Int
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Generic)
+
+instance FromJSON LocalRef
+instance ToJSON LocalRef
 
 data RemoteRef = RemoteRef
   { address :: String


### PR DESCRIPTION
We also use a `Codec` to serialise the `Message` type, similar to `Envelope`