### PR TITLE
journal

### DIFF
--- a/src/journal/src/Journal/Internal.hs
+++ b/src/journal/src/Journal/Internal.hs
@@ -144,7 +144,9 @@ termAppenderClaim meta termBuffer termId termOffset len = do
 
 handleEndOfLogCondition :: ByteBuffer -> TermOffset -> Capacity -> TermId -> IO ()
 handleEndOfLogCondition termBuffer termOffset (Capacity termLen) termId = do
+  putStrLn "handleEndOfLogCondition"
   when (termOffset < fromIntegral termLen) $ do
+    putStrLn "handleEndOfLogCondition: when"
 
     let paddingLength :: HeaderLength
         paddingLength = fromIntegral (termLen - fromIntegral termOffset)
@@ -176,6 +178,7 @@ rotateTerm meta = do
   let termId = rawTailTermId rawTail
       nextTermId = termId + 1
       termCount = fromIntegral (nextTermId - initTermId)
+  putStrLn ("rotateTerm, nextTermId: " ++ show (unTermId nextTermId))
 
   -- XXX: cache this? where exactly?
   -- activePartionIndex := nextIndex

--- a/src/journal/test/JournalTest.hs
+++ b/src/journal/test/JournalTest.hs
@@ -67,9 +67,7 @@ constructorString AppendBS {} = "AppendBS"
 constructorString ReadJournal = "ReadJournal"
 
 prettyCommand :: Command -> String
-prettyCommand (AppendBS rle) =
-  "AppendBS \"" ++ prettyRunLenEnc rle ++ "\""
-prettyCommand ReadJournal   = "ReadJournal"
+prettyCommand = show
 
 prettyCommands :: [Command] -> String
 prettyCommands = concat . go ["["] . map prettyCommand
@@ -287,6 +285,18 @@ runCommands cmds = do
 ------------------------------------------------------------------------
 
 -- XXX: make sure all these unit tests are part of the coverage...
+
+unit_bug0 :: Assertion
+unit_bug0 = assertProgram ""
+  [ AppendBS [(2, 'E')]
+  , AppendBS [(65524, 'O')]
+  ]
+
+unit_bug1 :: Assertion
+unit_bug1 = assertProgram ""
+  [ AppendBS [(65524, 'O')]
+  , AppendBS [(65524, 'G')]
+  ]
 
 {-
 nit_bug0 :: Assertion


### PR DESCRIPTION
- test(journal): generate long enough bytestrings to cause rotations
- refactor(journal): generate run length encodings rather than bytestrings
- test(journal): add tests for run length encoding
- test(journal): add unit tests for two bugs found by prop_journal
