### PR TITLE
fix(journal): in the model backpressure check if position is below the limit

### DIFF
--- a/src/journal/src/Journal/Internal.hs
+++ b/src/journal/src/Journal/Internal.hs
@@ -62,6 +62,7 @@ tryClaim jour len = do
   putStrLn ("tryClaim, termCount: " ++ show (unTermCount termCount))
   putStrLn ("tryClaim, activePartitionIndex: " ++ show (unPartitionIndex activePartitionIndex))
   putStrLn ("tryClaim, termOffset: " ++ show (unTermOffset termOffset))
+  putStrLn ("tryClaim, termBeginPosition: " ++ show termBeginPosition)
   limit <- calculatePositionLimit jour
   let termAppender = jTermBuffers jour Vector.! unPartitionIndex activePartitionIndex
       position     = termBeginPosition + fromIntegral termOffset

--- a/src/journal/test/JournalTest.hs
+++ b/src/journal/test/JournalTest.hs
@@ -67,18 +67,10 @@ appendBSFake bs fj@(FakeJournal bss ix)
     limit = readBytes + termLen `div` 2
 
     readBytes :: Int
-    readBytes = Vector.sum
-              . Vector.cons readPadBytes
+    readBytes = (+ readPadBytes)
+              . Vector.sum
               . Vector.map (\bs -> hEADER_LENGTH + BS.length bs)
               $ Vector.slice 0 (max 0 (ix - 1)) bss
-
-    readPadBytes :: Int
-    readPadBytes =
-      let
-        (lbss, _rbss) = Vector.splitAt ix (Vector.snoc bss bs)
-        (_lacc, lpad) = padding 0 0 (Vector.map BS.length lbss)
-      in
-        lpad
 
     unreadBytes :: Int
     unreadBytes = sum [ hEADER_LENGTH + BS.length bs
@@ -88,13 +80,14 @@ appendBSFake bs fj@(FakeJournal bss ix)
 
     -- XXX: figure out why this doesn't work:
     -- unreadBytes :: Int
-    -- unreadBytes = Vector.sum
-    --             . Vector.cons unreadPadBytes
+    -- unreadBytes = (+ unreadPadBytes)
+    --             . Vector.sum
     --             . Vector.map (\bs -> hEADER_LENGTH + BS.length bs)
     --             $ Vector.slice ix (max 0 (Vector.length bss - 1)) bss
 
-    unreadPadBytes :: Int
-    unreadPadBytes =
+
+    readPadBytes, unreadPadBytes :: Int
+    (readPadBytes, unreadPadBytes) =
       let
         (lbss, rbss) = Vector.splitAt ix (Vector.snoc bss bs)
         (lacc, lpad) = padding 0    0 (Vector.map BS.length lbss)
@@ -109,7 +102,7 @@ appendBSFake bs fj@(FakeJournal bss ix)
                        , "racc: " ++ show racc
                        , "rpad: " ++ show rpad
                        ])
-        rpad
+        (lpad, rpad)
 
     padding :: Int -> Int -> Vector Int -> (Int, Int)
     padding acc pad ls = case Vector.uncons ls of

--- a/src/journal/test/JournalTest.hs
+++ b/src/journal/test/JournalTest.hs
@@ -422,6 +422,16 @@ unit_bug5 = assertProgram ""
 -- related to the append of Rs, this gives us a position of 32770+32767 = 65537
 -- which is over the limit and so backpressure should happen.
 
+unit_bug6 :: Assertion
+unit_bug6 = assertProgram ""
+  [ AppendBS [(1,'J')], ReadJournal, AppendBS [(32757,'K')], AppendBS [(32761,'H')]
+  , AppendBS [(1,'F')]]
+
+unit_bug7 :: Assertion
+unit_bug7 = assertProgram ""
+  [AppendBS [(32756,'Y')], AppendBS [(32761,'A')], ReadJournal, AppendBS [(1,'J')]]
+
+
 ------------------------------------------------------------------------
 
 assertProgram :: String -> [Command] -> Assertion


### PR DESCRIPTION
(Rather than checking if unread bytes are below the limit.)
