### PR TITLE
journal

### DIFF
--- a/src/journal/test/JournalTest.hs
+++ b/src/journal/test/JournalTest.hs
@@ -765,6 +765,7 @@ shrinkConcProgram :: Model -> ConcProgram -> [ConcProgram]
 shrinkConcProgram m
   = filter (validConcProgram m)
   . map ConcProgram
+  . filter (not . null)
   . shrinkList (shrinkCommands m)
   . unConcProgram
 

--- a/src/journal/test/JournalTest.hs
+++ b/src/journal/test/JournalTest.hs
@@ -697,6 +697,14 @@ unit_bug23 = assertConcProgram "" $ ConcProgram
   , [ReadJournal,AppendBS [(20,'X')]]
   ]
 
+unit_bug24 :: Assertion
+unit_bug24 = assertConcProgram "" $ ConcProgram
+  [ [AppendBS [(32713,'F')]]
+  , [ReadJournal,AppendBS [(1,'Z')],AppendBS [(17,'T')]]
+  , [ReadJournal,AppendBS [(32753,'X')],ReadJournal]
+  , [AppendBS [(28,'K')],ReadJournal,AppendBS [(7682,'M')]]
+  ]
+
 alignedLength :: Int -> Int
 alignedLength n = align (hEADER_LENGTH + n) fRAME_ALIGNMENT
 

--- a/src/journal/test/JournalTest.hs
+++ b/src/journal/test/JournalTest.hs
@@ -766,7 +766,7 @@ shrinkConcProgram m
   = filter (validConcProgram m)
   . map ConcProgram
   . filter (not . null)
-  . shrinkList (shrinkCommands m)
+  . shrinkList (shrinkList shrinkCommand)
   . unConcProgram
 
 prettyConcProgram :: ConcProgram -> String


### PR DESCRIPTION
- test(journal): add new regression test
- refactor(journal): use run length encoding in model and responses
- fix(journal): fix two bugs in the model
- test(journal): add another counterexample
- test(journal): add more regression tests from counterexamples
- fix(journal): make hard limit more precise
- test(journal): add a couple of more regression tests related to backpressure
- fix(journal): return nothing in read if padding len is negative
- feat(journal): filter away empty concurrent chunks after shrinking
- fix(journal): don't filter invalid sequential programs when shrinking concurrent ones
- test(journal): add new regression test
