### PR TITLE
journal

### DIFF
--- a/src/journal/src/Journal/MP.hs
+++ b/src/journal/src/Journal/MP.hs
@@ -88,10 +88,10 @@ readJournal jour = do
         -- If the CAS fails, it just means that some other process incremented the
         -- counter already.
         readJournal jour
-      else return Nothing -- If len is negative then the writer hasn't
-                          -- finished writing the padding yet.
+      else readJournal jour -- If len is negative then the writer hasn't
+                            -- finished writing the padding yet.
     else if len <= 0
-         then return Nothing
+         then readJournal jour
          else do
            assertMMsg (show len) (len > 0)
            jLog ("readJournal, termCount: " ++ show (unTermCount termCount))

--- a/src/journal/test/JournalTest.hs
+++ b/src/journal/test/JournalTest.hs
@@ -714,6 +714,17 @@ unit_bug24 = assertConcProgram "" $ ConcProgram
   , [AppendBS [(28,'K')],ReadJournal,AppendBS [(7682,'M')]]
   ]
 
+unit_bug25 :: Assertion
+unit_bug25 = assertConcProgram "" $ ConcProgram
+  [ [AppendBS [(32760,'X')],AppendBS [(32760,'J')],AppendBS [(32759,'I')],
+     AppendBS [(32759,'P')],AppendBS [(32760,'C')]]
+  , [AppendBS [(32760,'O')],ReadJournal,AppendBS [(32759,'S')],AppendBS [(32760,'J')]]
+  , [AppendBS [(32760,'A')],AppendBS [(22,'O')],ReadJournal,AppendBS [(32760,'C')]]
+  , [ReadJournal,AppendBS [(20,'I')]]
+  , [AppendBS [(20,'C')],AppendBS [(32759,'L')],AppendBS [(20,'S')]]
+  , [ReadJournal,ReadJournal,AppendBS [(21,'Z')],AppendBS [(32759,'T')],ReadJournal]
+  ]
+
 alignedLength :: Int -> Int
 alignedLength n = align (hEADER_LENGTH + n) fRAME_ALIGNMENT
 

--- a/src/journal/test/JournalTest.hs
+++ b/src/journal/test/JournalTest.hs
@@ -681,9 +681,18 @@ unit_bug22 = assertConcProgram "" $ ConcProgram
   [ [AppendBS [(32697,'Y')],AppendBS [(32759,'S')],AppendBS [(19,'E')]]
   , [ReadJournal,AppendBS [(16,'I')]]
   , [AppendBS [(32760,'X')],ReadJournal,AppendBS [(32760,'H')]]
-  , []
   , [AppendBS [(16,'N')],AppendBS [(16,'Z')],AppendBS [(16,'R')],AppendBS [(32760,'B')],
      ReadJournal]
+  ]
+
+unit_bugSimple22 :: Assertion
+unit_bugSimple22 = assertConcProgram "" $ ConcProgram
+  [ [AppendBS [(19,'E')]]
+  , [AppendBS [(32759,'S')]]
+  , [ReadJournal]
+  , [ReadJournal]
+  , [AppendBS [(32760,'X')]]
+  , [AppendBS [(16,'N')], AppendBS [(16,'Z')], AppendBS [(32760,'B')], ReadJournal]
   ]
 
 unit_bug23 :: Assertion


### PR DESCRIPTION
- test(journal): add new regression test
- refactor(journal): use run length encoding in model and responses
- fix(journal): fix two bugs in the model
- test(journal): add another counterexample
- test(journal): add more regression tests from counterexamples
- fix(journal): make hard limit more precise
- test(journal): add a couple of more regression tests related to backpressure
- fix(journal): return nothing in read if padding len is negative
- feat(journal): filter away empty concurrent chunks after shrinking
- fix(journal): don't filter invalid sequential programs when shrinking concurrent ones
- test(journal): add new regression test
- fix(journal): block read on negative length
