### PR TITLE
journal

### DIFF
--- a/src/journal/src/Journal/Internal/BufferClaim.hs
+++ b/src/journal/src/Journal/Internal/BufferClaim.hs
@@ -31,6 +31,7 @@ commit :: BufferClaim -> Logger -> IO ()
 commit (BufferClaim bb) logger = do
   let Capacity frameLen = getCapacity bb
   logg logger ("commit, frameLen: " ++ show frameLen)
+  writeFrameType bb 0 Valid
   writeFrameLength bb 0 (HeaderLength (int2Int32 frameLen))
 
 abort :: BufferClaim -> IO ()

--- a/src/journal/src/Journal/MP.hs
+++ b/src/journal/src/Journal/MP.hs
@@ -90,7 +90,7 @@ readJournal jour = do
         readJournal jour
       else readJournal jour -- If len is negative then the writer hasn't
                             -- finished writing the padding yet.
-    else if len <= 0
+    else if len <= 0 || tag == Empty
          then readJournal jour
          else do
            assertMMsg (show len) (len > 0)


### PR DESCRIPTION
- test(journal): add new regression test
- refactor(journal): use run length encoding in model and responses
- fix(journal): fix two bugs in the model
- test(journal): add another counterexample
- test(journal): add more regression tests from counterexamples
- fix(journal): make hard limit more precise
- test(journal): add a couple of more regression tests related to backpressure
- fix(journal): return nothing in read if padding len is negative
- feat(journal): filter away empty concurrent chunks after shrinking
- fix(journal): don't filter invalid sequential programs when shrinking concurrent ones
- test(journal): add new regression test
- fix(journal): block read on negative length
- test(journal): add new regression test
- fix(journal): retry read on empty tag
