### PR TITLE
refactor(sut): Change the `Blocker` interface for dumblog

### DIFF
--- a/src/sut/dumblog/src/Dumblog/Journal/Main.hs
+++ b/src/sut/dumblog/src/Dumblog/Journal/Main.hs
@@ -14,7 +14,6 @@ import Journal.Types (Journal, Options, Subscriber(..), oLogger, oMaxSubscriber,
 import qualified Journal.MP as Journal
 import Journal.Internal.Logger as Logger
 import qualified Journal.Internal.Metrics as Metrics
-import qualified Journal.Types.AtomicCounter as AtomicCounter
 import Options.Generic
 
 import Dumblog.Journal.Blocker (emptyBlocker)
@@ -127,13 +126,12 @@ journalDumblog cfg _capacity port mReady = do
       mSnapshot <- Snapshot.readFile fps
       journal <- fetchJournal mSnapshot fpj opts
       metrics <- Metrics.newMetrics dumblogSchema fpm
-      blocker <- emptyBlocker
-      counter <- AtomicCounter.newCounter 0 -- it is okay to start over
+      blocker <- emptyBlocker 0 -- it is okay to start over
       cmds <- collectAll journal
       workerState <- replay cmds (startingState mSnapshot)
       let
         events = length cmds
-        feInfo = FrontEndInfo counter blocker
+        feInfo = FrontEndInfo blocker
         wInfo = WorkerInfo blocker fps events untilSnapshot
       withAsync (worker journal metrics wInfo workerState) $ \a -> do
         link a


### PR DESCRIPTION
The new interface removes the need for the worker thread needing to do retries,
instead the frontend will first add the key to the map, and then add the event
on the journal. This commit adds a `Key` type that bundles the `Int` key and the
`MVar`.

Another change is that the `AtomicCounter` has been moved to the `Blocker` type
rather than being part of the `FrontEndInfo` state. It makes more sense to have
the counter here, since now we want to add to the map when creating keys
anyways.