### PR TITLE
refactor(new-debugger): Remove the sequence diagram, move I/O to its …

### DIFF
--- a/src/new-debugger/src/Debugger/UI.hs
+++ b/src/new-debugger/src/Debugger/UI.hs
@@ -28,11 +28,10 @@ drawUI as = [ui]
              [ borderWithLabel (str "State") $ renderReactorState as
              , vLimitPercent 33 $ borderWithLabel (str "Events") $ renderEvents as
              ]
-           , borderWithLabel (str "Sequence Diagram") $ renderSeqDia as
-           ]
-         , vLimit 7 $ hBox
-           [ borderWithLabel (str "Input") $ renderMessage as
-           , borderWithLabel (str "Output") $ renderSentMessage as
+           , vBox
+             [ borderWithLabel (str "Input") $ renderMessage as
+             , borderWithLabel (str "Output") $ renderSentMessage as
+             ]
            ]
          , vLimit 7 $ borderWithLabel (str "Logs") $ renderLogs as
          ]


### PR DESCRIPTION
…place

We don't have a sequence diagram for the demo, so in order to not make it look
confusing, lets not show it. Move the I/O to its place to not make it as cramped.