### PR TITLE
minicourse

### DIFF
--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/Codec.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/Codec.hs
@@ -20,7 +20,7 @@ data SomeCodecSM = forall state request message response. Typeable state =>
                    SomeCodecSM (Codec request message response)
                                (SM state request message response)
 
-prepareInput :: Codec req msg resp -> RawInput -> Maybe (Input req msg)
-prepareInput codec (RawInput _to (ClientRequest at from bs)) = do
+decodeInput :: Codec req msg resp -> Input ByteString ByteString -> Maybe (Input req msg)
+decodeInput codec (ClientRequest at from bs) = do
   req <- cDecodeRequest codec bs
   return (ClientRequest at from req)

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/EventQueue.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/EventQueue.hs
@@ -21,7 +21,7 @@ isExitCommand (CommandEvent Exit) = True
 isExitCommand _otherwise          = False
 
 eventTime :: Event -> Time
-eventTime = undefined
+eventTime (NetworkEvent rawInput) = rawInputTime rawInput
 
 newtype EventQueue = EventQueue (TBQueue Event)
 

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/StateMachine.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/StateMachine.hs
@@ -6,10 +6,10 @@ import ATMC.Lec5.Time
 
 ------------------------------------------------------------------------
 
-newtype NodeId = NodeId Int
+newtype NodeId = NodeId { unNodeId :: Int }
   deriving (Eq, Ord, Show)
 
-newtype ClientId = ClientId Int
+newtype ClientId = ClientId { unClientId :: Int }
   deriving (Eq, Ord, Show)
 
 data SM state request message response = SM

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/StateMachine.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/StateMachine.hs
@@ -27,3 +27,10 @@ data Output response message
   deriving (Eq, Show)
 
 data RawInput = RawInput NodeId (Input ByteString ByteString)
+
+inputTime :: Input request message -> Time
+inputTime (ClientRequest   time _cid _req) = time
+inputTime (InternalMessage time _nid _msg) = time
+
+rawInputTime :: RawInput -> Time
+rawInputTime (RawInput _to input) = inputTime input

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/StateMachine.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/StateMachine.hs
@@ -26,8 +26,4 @@ data Output response message
   | InternalMessageOut NodeId message
   deriving (Eq, Show)
 
-inputReceiver :: RawInput -> NodeId
-inputReceiver (RawInput to (ClientRequest   _at _from _req)) = to
-inputReceiver (RawInput to (InternalMessage _at _from _msg)) = to
-
 data RawInput = RawInput NodeId (Input ByteString ByteString)

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5SimulationTestingV3.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5SimulationTestingV3.hs
@@ -53,11 +53,11 @@ runWorker topo queue ac clock net pids = go
     exit = mapM_ cancel pids
 
     handleEvent :: Event -> IO ()
-    handleEvent (NetworkEvent rawInput) =
-      case lookupReceiver (inputReceiver rawInput) topo of
+    handleEvent (NetworkEvent (RawInput nodeId rawInput)) =
+      case lookupReceiver nodeId topo of
         Nothing -> return () -- XXX: Log?
         Just (SomeCodecSM codec (SM state step)) ->
-          case prepareInput codec rawInput of
+          case decodeInput codec rawInput of
             Nothing -> return ()
             Just input -> do
               let (outputs, state') = step input state

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5SimulationTestingV3.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5SimulationTestingV3.hs
@@ -61,12 +61,12 @@ runWorker topo queue ac clock net pids = go
             Nothing -> return ()
             Just input -> do
               let (outputs, state') = step input state
-              mapM_ (handleOutput codec) outputs
+              mapM_ (handleOutput codec nodeId) outputs
 
     handleEvent (TimerEvent) = undefined
     handleEvent (CommandEvent Exit) = error "IMPOSSIBLE: this case has already been handled"
 
-    handleOutput codec (ClientResponse clientId response) =
+    handleOutput codec _fromNodeId (ClientResponse clientId response) =
       respondToAwaitingClient ac clientId (cEncodeResponse codec response)
-    handleOutput codec (InternalMessageOut nodeId msg) =
-      nSend net nodeId (cEncodeMessage codec msg)
+    handleOutput codec fromNodeId (InternalMessageOut toNodeId msg) =
+      nSend net fromNodeId toNodeId (cEncodeMessage codec msg)


### PR DESCRIPTION
- feat(course): add new version of event loop
- feat(course): separate codec and add sm dsl
- feat(course): remove receiver from input and proxy from dsl
- feat(course): finish dsl example by constructing sm using runSMM
- refactor(course): s/reply/respond/
- feat(course): add get state to dsl
- fix(course): remove req from sm monad
- refactor(course): simplify raw input decoding
- refactor(course): give send access to sender node id
- feat(course): finish real network
