### PR TITLE
minicourse

### DIFF
--- a/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
+++ b/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
@@ -36,6 +36,7 @@ library
                   , text
                   , http-client
                   , microlens-platform
+                  , random
                   , stm
                   , transformers
                   , time
@@ -67,7 +68,7 @@ library
 
   default-language: Haskell2010
 
-executable advanced-testing-mini-course
+executable lec5
   main-is:          Main.hs
 
   -- Modules included in this executable, other than Main.

--- a/doc/advanced-testing-mini-course/app/Main.hs
+++ b/doc/advanced-testing-mini-course/app/Main.hs
@@ -1,5 +1,7 @@
 module Main where
 
+import System.Environment
+
 import ATMC.Lec5SimulationTestingV3
 import ATMC.Lec5.StateMachine
 import ATMC.Lec5.Codec
@@ -7,4 +9,8 @@ import ATMC.Lec5.Codec
 ------------------------------------------------------------------------
 
 main :: IO ()
-main = eventLoopProduction [SomeCodecSM idCodec echoSM]
+main = do
+  args <- getArgs
+  case args of
+    ["--simulation"] -> eventLoopSimulation echoAgenda [SomeCodecSM idCodec echoSM]
+    _otherwise       -> eventLoopProduction [SomeCodecSM idCodec echoSM]

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/Agenda.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/Agenda.hs
@@ -9,33 +9,36 @@ import Data.List (foldl')
 import Data.Foldable
 
 import ATMC.Lec5.Time
+import ATMC.Lec5.Event (RawInput)
 
 ------------------------------------------------------------------------
 
-newtype Agenda e = Agenda (Heap (Entry Time e))
+newtype Agenda' e = Agenda (Heap (Entry Time e))
   deriving newtype (Semigroup, Monoid)
   deriving stock Show
 
-emptyAgenda :: Agenda e
+type Agenda = Agenda' RawInput
+
+emptyAgenda :: Agenda' e
 emptyAgenda = Agenda Heap.empty
 
-union :: Agenda e -> Agenda e -> Agenda e
+union :: Agenda' e -> Agenda' e -> Agenda' e
 union (Agenda h) (Agenda h') = Agenda (h `Heap.union` h')
 
-fromList :: [(Time, e)] -> Agenda e
-fromList = Agenda . Heap.fromList . map (uncurry Entry)
+makeAgenda :: [(Time, e)] -> Agenda' e
+makeAgenda = Agenda . Heap.fromList . map (uncurry Entry)
 
-pop :: Agenda e -> Maybe ((Time, e), Agenda e)
+pop :: Agenda' e -> Maybe ((Time, e), Agenda' e)
 pop (Agenda h) = case Heap.uncons h of
   Nothing              -> Nothing
   Just (Entry t e, h') -> Just ((t, e), Agenda h')
 
-push :: (Time, e) -> Agenda e -> Agenda e
+push :: (Time, e) -> Agenda' e -> Agenda' e
 push (t, e) (Agenda h) = Agenda (Heap.insert (Entry t e) h)
 
-pushList :: [(Time, e)] -> Agenda e -> Agenda e
+pushList :: [(Time, e)] -> Agenda' e -> Agenda' e
 pushList tes (Agenda h) =
   Agenda (foldl' (\ih (t, e) -> Heap.insert (Entry t e) ih) h tes)
 
-filterAgenda :: (e -> Bool) -> Agenda e -> [e]
+filterAgenda :: (e -> Bool) -> Agenda' e -> [e]
 filterAgenda p (Agenda h) = filter p (map Heap.payload (toList h))

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/Event.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/Event.hs
@@ -11,6 +11,7 @@ data Event
   = NetworkEvent RawInput
   | TimerEvent -- TimerEvent
   | CommandEvent CommandEvent
+  deriving Show
 
 data RawInput = RawInput NodeId (Input ByteString ByteString)
   deriving Show
@@ -23,6 +24,7 @@ rawInputTime :: RawInput -> Time
 rawInputTime (RawInput _to input) = inputTime input
 
 data CommandEvent = Exit
+  deriving Show
 
 isExitCommand :: Event -> Bool
 isExitCommand (CommandEvent Exit) = True

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/Options.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/Options.hs
@@ -6,7 +6,7 @@ import ATMC.Lec5.StateMachine
 
 ------------------------------------------------------------------------
 
-data Deployment = Production | Simulation (Agenda RawInput)
+data Deployment = Production | Simulation Agenda
   deriving Show
 
 data Options = Options

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/SmartBFT/Machine.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/SmartBFT/Machine.hs
@@ -107,4 +107,4 @@ initState :: SBFTState
 initState = tODO
 
 sm :: SM SBFTState SBFTRequest SBFTMessage Response
-sm = SM initState (runSMM . machine)
+sm = SM initState (runSMM 0 . machine)

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/Time.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/Time.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingStrategies #-}
+
 module ATMC.Lec5.Time where
 
 import Data.IORef
@@ -8,7 +10,7 @@ import Data.Time.Calendar.OrdinalDate
 ------------------------------------------------------------------------
 
 newtype Time = Time UTCTime
-  deriving (Eq, Ord, Show)
+  deriving stock (Eq, Ord, Show)
 
 addTime :: NominalDiffTime -> Time -> Time
 addTime secs (Time t) = Time (addUTCTime secs t)


### PR DESCRIPTION
- feat(course): add better error handling and logging
- fix(course): make real network work and improve error handling and logging
- feat(course): catch exceptions when stepping state machines
- refactor(course): remove event queue
- feat(course): add fake network
- feat(course): add agenda to simulation option
- feat(course): move awaiting clients into network module
- refactor(course): use microlens instead of hasfield
- feat(course): add random for SMM and hook up simulation to main
