### PR TITLE
minicourse

### DIFF
--- a/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
+++ b/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
@@ -64,6 +64,7 @@ library
     ATMC.Lec5.StateMachine
     ATMC.Lec5.StateMachineDSL
     ATMC.Lec5.Time
+    ATMC.Lec5.TimerWheel
     ATMC.Lec5.ViewstampReplication.Machine
     ATMC.Lec5.ViewstampReplication.Message
     ATMC.Lec5.ViewstampReplication.State

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/StateMachine.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/StateMachine.hs
@@ -1,5 +1,6 @@
 module ATMC.Lec5.StateMachine where
 
+import Data.Fixed
 import Data.ByteString.Lazy (ByteString)
 
 import ATMC.Lec5.Time
@@ -27,6 +28,8 @@ data Input request message
 data Output response message
   = ClientResponse ClientId response
   | InternalMessageOut NodeId message
+  | RegisterTimerSeconds Pico
+  | ResetTimerSeconds Pico
   deriving (Eq, Show)
 
 echoSM :: SM () ByteString ByteString ByteString

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/TimerWheel.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/TimerWheel.hs
@@ -1,0 +1,47 @@
+module ATMC.Lec5.TimerWheel where
+
+import Data.Time
+import Data.Fixed
+import Data.Foldable
+import Data.IORef
+import Data.Heap (Entry(Entry), Heap)
+import qualified Data.Heap as Heap
+
+import ATMC.Lec5.Time
+import ATMC.Lec5.StateMachine
+
+------------------------------------------------------------------------
+
+newtype TimerWheel = TimerWheel (IORef (Heap (Entry Time NodeId)))
+
+newTimerWheel :: IO TimerWheel
+newTimerWheel = do
+  ref <- newIORef Heap.empty
+  return (TimerWheel ref)
+
+registerTimer :: TimerWheel -> Clock -> NodeId -> Pico -> IO ()
+registerTimer (TimerWheel hr) clock nodeId secs = do
+  now <- cGetCurrentTime clock
+  let expires = addTime (secondsToNominalDiffTime secs) now
+  atomicModifyIORef' hr (\h -> (Heap.insert (Entry expires nodeId) h, ()))
+
+resetTimer :: TimerWheel -> Clock -> NodeId -> Pico -> IO ()
+resetTimer (TimerWheel hr) clock nodeId secs = do
+  now <- cGetCurrentTime clock
+  let expires = addTime (secondsToNominalDiffTime secs) now
+  atomicModifyIORef' hr (\h -> (Heap.map (go expires) h, ()))
+    where
+      go expires e@(Entry _expires nodeId')
+        | nodeId' == nodeId = Entry expires nodeId
+        | otherwise         = e
+
+expiredTimers :: TimerWheel -> Clock -> IO [(Time, NodeId)]
+expiredTimers (TimerWheel hr) clock  = do
+  h <- readIORef hr
+  now <- cGetCurrentTime clock
+  return (go (toList h) now [])
+    where
+      go :: [Entry Time NodeId] -> Time -> [(Time, NodeId)] -> [(Time, NodeId)]
+      go []                   _now acc             = reverse acc
+      go (Entry t nodeId : es) now acc | t <= now  = go es now ((t, nodeId) : acc)
+                                       | otherwise = reverse acc

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5SimulationTestingV3.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5SimulationTestingV3.hs
@@ -107,6 +107,10 @@ runWorker config clock net cmdQ pids = go
           nRespond net clientId (cEncodeResponse codec response)
         handleOutput codec fromNodeId (InternalMessageOut toNodeId msg) =
           nSend net fromNodeId toNodeId (cEncodeMessage codec msg)
+        handleOutput _codec fromNodeId (RegisterTimerSeconds secs) =
+          undefined -- registerTimer timerWheel clock fromNodeId secs
+        handleOutput _codec fromNodeId (ResetTimerSeconds secs) =
+          undefined -- resetTimer timerWheel clock fromNodeId secs
 
     handleEvent (TimerEvent) = undefined
     handleEvent (CommandEvent Exit) = error "IMPOSSIBLE: this case has already been handled"


### PR DESCRIPTION
- fix(course): unbreak vr module after last commit
- refactor(course): add newtype around seed
- feat(course): make fake network exit on empty agenda
- feat(course): first steps towards saving history
- feat(course): enable MonadPlus instance for SMM
- feat(course): first steps towards timers
