### PR TITLE
minicourse

### DIFF
--- a/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
+++ b/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
@@ -57,6 +57,7 @@ library
     ATMC.Lec5.Codec
     ATMC.Lec5.Configuration
     ATMC.Lec5.Event
+    ATMC.Lec5.EventQueue
     ATMC.Lec5.History
     ATMC.Lec5.Network
     ATMC.Lec5.Options

--- a/doc/advanced-testing-mini-course/app/Main.hs
+++ b/doc/advanced-testing-mini-course/app/Main.hs
@@ -4,6 +4,7 @@ import System.Environment
 
 import ATMC.Lec5SimulationTestingV3
 import ATMC.Lec5.StateMachine
+import ATMC.Lec5.Configuration
 import ATMC.Lec5.Codec
 
 ------------------------------------------------------------------------

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/EventQueue.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/EventQueue.hs
@@ -1,0 +1,29 @@
+module ATMC.Lec5.EventQueue where
+
+import Control.Concurrent.STM
+import Control.Concurrent.STM.TQueue
+
+import ATMC.Lec5.Event
+import ATMC.Lec5.Options
+
+------------------------------------------------------------------------
+
+data EventQueue = EventQueue
+  { eqEnqueue :: Event -> IO ()
+  , eqDequeue :: IO Event
+  }
+
+realEventQueue :: IO EventQueue
+realEventQueue = do
+  q <- newTQueueIO
+  return EventQueue
+    { eqEnqueue = atomically . writeTQueue q
+    , eqDequeue = atomically (readTQueue q)
+    }
+
+fakeEventQueue :: IO EventQueue
+fakeEventQueue = undefined
+
+newEventQueue :: DeploymentMode -> IO EventQueue
+newEventQueue Production          = realEventQueue
+newEventQueue (Simulation agenda) = fakeEventQueue

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/Options.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/Options.hs
@@ -1,16 +1,15 @@
 module ATMC.Lec5.Options where
 
 import ATMC.Lec5.Agenda
-import ATMC.Lec5.Event
 import ATMC.Lec5.StateMachine
 
 ------------------------------------------------------------------------
 
-data Deployment = Production | Simulation Agenda
+data DeploymentMode = Production | Simulation Agenda
   deriving Show
 
 data Options = Options
-  { oDeployment :: Deployment
+  { oDeployment :: DeploymentMode
   -- , oTimerFreq :: Double -- Hz (cycles per second)
   -- oClientTimeoutNanos :: Int
   }


### PR DESCRIPTION
- feat(course): early return
- refactor(course): remove maybe from smm (previously need for monad plus)
- fix(course): fix early return and guard
- feat(course): more on timers and move configuration to own module
- fix(course): update state of SMs after stepping them
- feat(course): add event queue interface and implement it for production
