### PR TITLE
minicourse

### DIFF
--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/Agenda.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/Agenda.hs
@@ -9,7 +9,7 @@ import Data.List (foldl')
 import Data.Foldable
 
 import ATMC.Lec5.Time
-import ATMC.Lec5.Event (NetworkEvent)
+import ATMC.Lec5.Event (Event)
 
 ------------------------------------------------------------------------
 
@@ -17,7 +17,7 @@ newtype Agenda' e = Agenda (Heap (Entry Time e))
   deriving newtype (Semigroup, Monoid)
   deriving stock Show
 
-type Agenda = Agenda' NetworkEvent -- XXX: should be Event
+type Agenda = Agenda' Event
 
 emptyAgenda :: Agenda' e
 emptyAgenda = Agenda Heap.empty

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/Event.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/Event.hs
@@ -19,13 +19,23 @@ data NetworkEvent = NetworkEvent NodeId (Input ByteString ByteString)
 data TimerEvent = TimerEvent NodeId Time
   deriving Show
 
-eventTime :: Event -> Time
-eventTime (TimerEventE   (TimerEvent   _nodeId time))  = time
-eventTime (NetworkEventE (NetworkEvent _nodeId input)) = inputTime input
+getEventTime :: Event -> Time
+getEventTime (TimerEventE   (TimerEvent   _nodeId time))  = time
+getEventTime (NetworkEventE (NetworkEvent _nodeId input)) = getInputTime input
   where
-    inputTime :: Input request message -> Time
-    inputTime (ClientRequest   time _cid _req) = time
-    inputTime (InternalMessage time _nid _msg) = time
+    getInputTime :: Input request message -> Time
+    getInputTime (ClientRequest   time _cid _req) = time
+    getInputTime (InternalMessage time _nid _msg) = time
+
+setEventTime :: Time -> Event -> Event
+setEventTime time (TimerEventE (TimerEvent nodeId _time)) =
+                   TimerEventE (TimerEvent nodeId time)
+setEventTime time (NetworkEventE (NetworkEvent nodeId input)) =
+                   NetworkEventE (NetworkEvent nodeId (setInputTime time input))
+  where
+    setInputTime :: Time -> Input request message -> Input request message
+    setInputTime time (ClientRequest _time cid req)   = ClientRequest time cid req
+    setInputTime time (InternalMessage _time nid msg) = InternalMessage time nid msg
 
 data CommandEvent = Exit
   deriving Show

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5SimulationTestingV3.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5SimulationTestingV3.hs
@@ -35,14 +35,14 @@ eventLoopSimulation agenda =
 
 echoAgenda :: Agenda
 echoAgenda = makeAgenda
-  [(epoch, NetworkEvent (NodeId 0) (ClientRequest epoch (ClientId 0) "hi"))]
+  [(epoch, NetworkEventE (NetworkEvent (NodeId 0) (ClientRequest epoch (ClientId 0) "hi")))]
 
 eventLoop :: Options -> Configuration -> IO ()
 eventLoop opts config = do
   putStrLn ("Starting event loop in " ++ show (oDeployment opts) ++
             " mode on port: "  ++ show pORT)
   clock <- newClock (oDeployment opts)
-  evQ   <- newEventQueue (oDeployment opts)
+  evQ   <- newEventQueue (oDeployment opts) clock
   net   <- newNetwork (oDeployment opts) evQ clock
   withAsync (nRun net) $ \anet -> do
     link anet
@@ -72,7 +72,7 @@ runWorker config clock net evQ pids = go
       if isExitCommand event
       then exit
       else do
-        cSetCurrentTime clock (eventTime event) -- This is a noop in production deployment.
+        cSetCurrentTime clock (getEventTime event) -- This is a noop in production deployment.
         handleEvent event
         go
 


### PR DESCRIPTION
- feat(course): early return
- refactor(course): remove maybe from smm (previously need for monad plus)
- fix(course): fix early return and guard
- feat(course): more on timers and move configuration to own module
- fix(course): update state of SMs after stepping them
- feat(course): add event queue interface and implement it for production
- feat(course): finish simulation implementation of event queue interface
