### PR TITLE
minicourse

### DIFF
--- a/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
+++ b/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
@@ -56,6 +56,7 @@ library
     ATMC.Lec5.AwaitingClients
     ATMC.Lec5.Codec
     ATMC.Lec5.Configuration
+    ATMC.Lec5.Deployment
     ATMC.Lec5.Event
     ATMC.Lec5.EventQueue
     ATMC.Lec5.History

--- a/doc/advanced-testing-mini-course/app/Main.hs
+++ b/doc/advanced-testing-mini-course/app/Main.hs
@@ -6,6 +6,7 @@ import ATMC.Lec5SimulationTestingV3
 import ATMC.Lec5.StateMachine
 import ATMC.Lec5.Configuration
 import ATMC.Lec5.Codec
+import ATMC.Lec5.History
 
 ------------------------------------------------------------------------
 
@@ -13,5 +14,9 @@ main :: IO ()
 main = do
   args <- getArgs
   case args of
-    ["--simulation"] -> eventLoopSimulation echoAgenda [SomeCodecSM idCodec echoSM]
+    ["--simulation"] -> do
+      h <- newHistory
+      eventLoopSimulation echoAgenda h [SomeCodecSM idCodec echoSM]
+      _history <- readHistory h
+      putStrLn "Can't print history yet, need Show/Pretty constraints for parameters..."
     _otherwise       -> eventLoopProduction [SomeCodecSM idCodec echoSM]

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/Deployment.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/Deployment.hs
@@ -1,0 +1,65 @@
+module ATMC.Lec5.Deployment where
+
+import Control.Concurrent.Async
+
+import ATMC.Lec5.History
+import ATMC.Lec5.Agenda
+import ATMC.Lec5.EventQueue
+import ATMC.Lec5.Configuration
+import ATMC.Lec5.Time
+import ATMC.Lec5.TimerWheel
+import ATMC.Lec5.Network
+
+------------------------------------------------------------------------
+
+data DeploymentMode = Production | Simulation Agenda History
+
+displayDeploymentMode :: DeploymentMode -> String
+displayDeploymentMode Production    = "production"
+displayDeploymentMode Simulation {} = "simulation"
+
+data Deployment = Deployment
+  { dMode          :: DeploymentMode
+  , dConfiguration :: Configuration
+  , dClock         :: Clock
+  , dEventQueue    :: EventQueue
+  , dNetwork       :: Network
+  , dTimerWheel    :: TimerWheel
+  , dPids          :: Pids
+  , dAppendHistory :: HistEvent -> IO ()
+  }
+
+newtype Pids = Pids { unPids :: [Async ()] }
+
+newDeployment :: DeploymentMode -> Configuration -> IO Deployment
+newDeployment mode config = case mode of
+  Production -> do
+    clock      <- realClock
+    eventQueue <- realEventQueue clock
+    network    <- realNetwork eventQueue clock
+    timerWheel <- newTimerWheel
+    return Deployment
+      { dMode          = mode
+      , dConfiguration = config
+      , dClock         = clock
+      , dEventQueue    = eventQueue
+      , dNetwork       = network
+      , dTimerWheel    = timerWheel
+      , dPids          = Pids []
+      , dAppendHistory = \_ -> return ()
+      }
+  Simulation agenda history -> do
+    clock      <- fakeClockEpoch
+    eventQueue <- fakeEventQueue agenda clock
+    network    <- fakeNetwork eventQueue clock
+    timerWheel <- newTimerWheel
+    return Deployment
+      { dMode          = mode
+      , dConfiguration = config
+      , dClock         = clock
+      , dEventQueue    = eventQueue
+      , dNetwork       = network
+      , dTimerWheel    = timerWheel
+      , dPids          = Pids []
+      , dAppendHistory = appendHistory history
+      }

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/EventQueue.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/EventQueue.hs
@@ -7,7 +7,6 @@ import Data.IORef
 import ATMC.Lec5.Agenda
 import ATMC.Lec5.Event
 import ATMC.Lec5.Time
-import ATMC.Lec5.Options
 
 ------------------------------------------------------------------------
 
@@ -43,7 +42,3 @@ fakeEventQueue a clock = do
         Just ((_time, event), a') -> do
           writeIORef agenda a'
           return event
-
-newEventQueue :: DeploymentMode -> Clock -> IO EventQueue
-newEventQueue Production          = realEventQueue
-newEventQueue (Simulation agenda) = fakeEventQueue agenda

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/History.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/History.hs
@@ -2,9 +2,25 @@
 
 module ATMC.Lec5.History where
 
+import Control.Concurrent.STM
+import Control.Concurrent.STM.TQueue
+
 import ATMC.Lec5.StateMachine
 
 ------------------------------------------------------------------------
 
+newtype History = History (TQueue HistEvent)
+
 data HistEvent = forall state req msg resp.
   HistEvent NodeId state (Input req msg) state [Output resp msg]
+
+newHistory :: IO History
+newHistory = do
+  q <- newTQueueIO
+  return (History q)
+
+appendHistory :: History -> HistEvent -> IO ()
+appendHistory (History q) ev = atomically (writeTQueue q ev)
+
+readHistory :: History -> IO [HistEvent]
+readHistory (History q) = atomically (flushTQueue q)

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/Network.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/Network.hs
@@ -21,7 +21,6 @@ import System.Exit
 
 import ATMC.Lec5.Agenda
 import ATMC.Lec5.AwaitingClients
-import ATMC.Lec5.Options
 import ATMC.Lec5.StateMachine
 import ATMC.Lec5.Time
 import ATMC.Lec5.Event
@@ -121,7 +120,3 @@ fakeNetwork evQ clock = do
 
     respond :: ClientId -> ByteString -> IO ()
     respond _clientId _resp = return ()
-
-newNetwork :: DeploymentMode -> EventQueue -> Clock -> IO Network
-newNetwork Production           = realNetwork
-newNetwork (Simulation _agenda) = fakeNetwork

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5/Options.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5/Options.hs
@@ -1,12 +1,8 @@
 module ATMC.Lec5.Options where
 
-import ATMC.Lec5.Agenda
-import ATMC.Lec5.StateMachine
+import ATMC.Lec5.Deployment
 
 ------------------------------------------------------------------------
-
-data DeploymentMode = Production | Simulation Agenda
-  deriving Show
 
 data Options = Options
   { oDeployment :: DeploymentMode


### PR DESCRIPTION
- feat(course): hook up timers to event loop
- build(sut): pin tree-diff to last BSD3 version in cabal file
- feat(course): move arrival time generation from event queue to network
- feat(course): record history during simulation
