### PR TITLE
minicourse

### DIFF
--- a/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
+++ b/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
@@ -80,6 +80,8 @@ library
     ATMC.Lec6WhiteboxCheckers
     ATMC.Lec7EfficientEventLoop
     ATMC.Lec8AsyncFileSystemIO
+    ATMC.Lec9SMUpgrades
+    ATMC.Lec10LibraryOrFramework
     Experiment.Simulation
 
   default-language: Haskell2010

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec10LibraryOrFramework.lhs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec10LibraryOrFramework.lhs
@@ -1,0 +1,18 @@
+> module ATMC.Lec10LibraryOrFramework where
+
+Motivation
+----------
+
+- How can we take everything we've done so far and pack it up in a nice way so
+  that many different applications can be written, easily communicate with each
+  other all while being conveniently debuggable?
+
+
+See also
+--------
+
+- Jane Street's
+  [Concord](https://signalsandthreads.com/state-machine-replication-and-why-you-should-care/)
+  framework
+
+- Chuck's Bandwagon framework

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec9SMUpgrades.lhs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec9SMUpgrades.lhs
@@ -1,0 +1,22 @@
+> module ATMC.Lec9SMUpgrades where
+
+State machine upgrades
+======================
+
+Motivation
+----------
+
+- How do we upgrade the state machines?
+
+Plan
+----
+
+- Versioning of all messages
+- Codec upgrades
+- State machine upgrades
+- Seralisation of state machines?
+
+See also
+--------
+
+- Erlang hot-code swapping


### PR DESCRIPTION
- feat(course): towards integrating lec2 checker with lec5 output
- feat(course): implement blackbox history
- refactor(course): remove typeable msg constraint from blackbox history
- fix(course): add missing cases in blackbox history
- refactor(course): clean up main
- feat(course): more on discussion and see alsos, as well as skeleton for lec 6-8
- feat(course): add two more future work chapters
