### PR TITLE
minicourse

### DIFF
--- a/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
+++ b/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
@@ -52,8 +52,11 @@ library
     ATMC.Lec1SMTesting
     ATMC.Lec2ConcurrentSMTesting
     ATMC.Lec3SMContractTesting
+    ATMC.Lec3.QueueInterface
     ATMC.Lec3.Queue
     ATMC.Lec3.QueueTest
+    ATMC.Lec3.Service
+    ATMC.Lec3.ServiceTest
     ATMC.Lec4FaultInjection
     ATMC.Lec5.Agenda
     ATMC.Lec5.AwaitingClients

--- a/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
+++ b/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
@@ -40,6 +40,7 @@ library
     , QuickCheck
     , random
     , stm
+    , sqlite-simple
     , text
     , time
     , transformers

--- a/doc/advanced-testing-mini-course/src/ATMC.lhs
+++ b/doc/advanced-testing-mini-course/src/ATMC.lhs
@@ -26,10 +26,35 @@ Advanced property-based testing mini-course
       programs](http://www.cs.tufts.edu/~nr/cs257/archive/john-hughes/quick.pdf)
       (2000) by Koen Claessen and John Hughes
 
+Structure
+---------
+
+Each lecture has the following structure:
+
+- Motiviation: explains why we are doing what we are about to do;
+- Plan: how we will do it;
+- Code: an implementation of the idea;
+- Discussion: common questions or objections;
+- Exercises: things the authors were to lazy to do, but they know how to;
+- Problems: things the authors don't know how to do (yet);
+- See also: links to further reading about the topic or related topics;
+- Summary: the most important take away.
+
+The lectures build upon each other. We start by modelling and testing a simple
+counter using a state machine in lecture 1, we then reuse the same state machine
+model to test the counter of thread-safety using linearisability in lecture 2.
+In lecture 3 we will implement a queue and a web service that uses said queue,
+the state machine model for the queue and the real implementation of the queue
+will be contract tested to ensure that the model is faithful to the
+implementation, subsequently while testing the web service we will use the model
+in place of the real queue. In lecture 4 we introduce fault injection to the
+queue allowing us to test how the web service performs when its dependency
+fails. Finally, in lecture 5, we combine all the above ideas in what, sometimes
+is called simulation testing, to test a distributed system that uses replicated
+state machines.
+
 Table of contents
 -----------------
-
-> import ATMC.Lec1SMTesting
 
 1. State machine testing
   - State machine models
@@ -39,24 +64,18 @@ Table of contents
   - Regression tests from counterexamples
   - Metrics
   - References?
-
-> import ATMC.Lec2ConcurrentSMTesting
-
 2. Concurrent state machine testing with linearisability
   - Generalise generation and execution to N threads
   - Collect history
   - Enumerate all possible sequential executions from concurrent history
   - Write simple linearisability checker: check if there's any such sequential
     execution that satisifies the (sequential) state machine model
-
-> import ATMC.Lec3SMContractTesting
-
 3. Consumer-driven contract tests using state machines
-
-> import ATMC.Lec4FaultInjection
-
 4. Fault-injection
-
-> import ATMC.Lec5SimulationTesting
-
 5. Simulation testing
+
+> import ATMC.Lec1SMTesting
+> import ATMC.Lec2ConcurrentSMTesting
+> import ATMC.Lec3SMContractTesting
+> import ATMC.Lec4FaultInjection
+> import ATMC.Lec5SimulationTesting

--- a/doc/advanced-testing-mini-course/src/ATMC.lhs
+++ b/doc/advanced-testing-mini-course/src/ATMC.lhs
@@ -11,20 +11,21 @@ Advanced property-based testing mini-course
   - Introduce the reader to related work and open problems in the area.
 
 + Pre-requisites:
-  - Enough familiarity with Haskell to be able to read simple programs;
-  - Basic knowledge of state machines (i.e. Mealy and Moore machines)
 
-    + https://en.wikipedia.org/wiki/Finite-state_transducer
-    + [Computation and State
-      Machines](https://www.microsoft.com/en-us/research/publication/computation-state-machines/)
-      (2008) by Leslie Lamport
+  - Enough familiarity with Haskell to be able to read simple programs, for
+    example if you can follow along in the *Learn You a Haskell for Great Good!*
+    [tutorial](http://learnyouahaskell.com/chapters), then you should be fine;
+
+  - Basic knowledge of state machines (i.e.
+    [Mealy](https://en.wikipedia.org/wiki/Mealy_machine) / [Moore
+    machines](https://en.wikipedia.org/wiki/Moore_machine) and
+    [transducers](https://en.wikipedia.org/wiki/Finite-state_transducer)).
 
   - Some experience with property-based testing of non-stateful (i.e. pure)
-    programs.
-    + The original paper: [QuickCheck: a lightweight tool for random testing of
-      Haskell
-      programs](http://www.cs.tufts.edu/~nr/cs257/archive/john-hughes/quick.pdf)
-      (2000) by Koen Claessen and John Hughes
+    programs. For example as explained in the official QuickCheck
+    [manual](http://www.cse.chalmers.se/~rjmh/QuickCheck/manual.html) or in the
+    following
+    [tutorial](https://begriffs.com/posts/2017-01-14-design-use-quickcheck.html).
 
 Structure
 ---------

--- a/doc/advanced-testing-mini-course/src/ATMC.lhs
+++ b/doc/advanced-testing-mini-course/src/ATMC.lhs
@@ -1,5 +1,3 @@
-> module ATMC where
-
 Advanced property-based testing mini-course
 ===========================================
 
@@ -74,6 +72,8 @@ Table of contents
 3. Consumer-driven contract tests using state machines
 4. Fault-injection
 5. Simulation testing
+
+> module ATMC where
 
 > import ATMC.Lec1SMTesting
 > import ATMC.Lec2ConcurrentSMTesting

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec3/QueueInterface.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec3/QueueInterface.hs
@@ -1,0 +1,6 @@
+module ATMC.Lec3.QueueInterface where
+
+data QueueI a = QueueI
+  { qiEnqueue :: a -> IO Bool
+  , qiDequeue :: IO (Maybe a)
+  }

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec3/QueueTest.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec3/QueueTest.hs
@@ -47,7 +47,7 @@ fakeEnqueue x m
 fakeDequeue :: Model a -> (Model a, Maybe a)
 fakeDequeue m = case mQueue m of
   []       -> (m, Nothing)
-  (x : xs) -> (m { mQueue = xs }, (Just x))
+  (x : xs) -> (m { mQueue = xs }, Just x)
 
 step :: Command a -> Model a -> (Model a, Response a)
 step Size        m = (m, Int (length (mQueue m)))
@@ -102,8 +102,8 @@ newtype Capacity = Capacity Int
 instance Arbitrary Capacity where
   arbitrary = Capacity <$> choose (0, 5)
 
-prop_queue :: Capacity -> Property
-prop_queue (Capacity cap) =
+prop_contractTests :: Capacity -> Property
+prop_contractTests (Capacity cap) =
   forAllShrink (genCommands cap 0) (shrinkList (const [])) $ \cmds -> monadicIO $ do
     let m = newModel cap
     q <- run (newQueue cap)

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec3/Service.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec3/Service.hs
@@ -1,0 +1,131 @@
+module ATMC.Lec3.Service where
+
+import Control.Concurrent
+import Control.Concurrent.Async
+import Control.Concurrent.STM
+import Data.ByteString.Lazy (ByteString)
+import Data.IORef
+import qualified Data.ByteString.Lazy.Char8 as BS8
+import Network.HTTP.Types.Status
+import Network.Wai
+import Network.Wai.Handler.Warp
+import System.Environment
+
+import ATMC.Lec3.Queue
+import ATMC.Lec3.QueueTest (fakeEnqueue, fakeDequeue, newModel)
+import ATMC.Lec3.QueueInterface
+
+------------------------------------------------------------------------
+
+mAX_QUEUE_SIZE :: Int
+mAX_QUEUE_SIZE = 128
+
+pORT :: Int
+pORT = 8050
+
+data Mode = Testing | Production
+
+------------------------------------------------------------------------
+
+realQueue :: Int -> IO (QueueI a)
+realQueue size = do
+  q <- newQueue size
+  return QueueI
+    { qiEnqueue = enqueue q
+    , qiDequeue = dequeue q
+    }
+
+fakeQueue :: Int -> IO (QueueI a)
+fakeQueue size = do
+  ref <- newIORef (newModel size)
+  return QueueI
+    { qiEnqueue = \x -> atomicModifyIORef' ref (fakeEnqueue x)
+    , qiDequeue =       atomicModifyIORef' ref fakeDequeue
+    }
+
+------------------------------------------------------------------------
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case args of
+    ["--testing"] -> service Testing
+    _otherwise    -> service Production
+
+service :: Mode -> IO ()
+service mode = do
+  queue <- case mode of
+             Testing -> fakeQueue mAX_QUEUE_SIZE
+  ready <- newEmptyMVar
+  withAsync (worker queue) $ \_async ->
+    runFrontEnd queue pORT ready
+
+worker :: QueueI Command -> IO ()
+worker queue = go initState
+  where
+    go :: State -> IO ()
+    go state = do
+      cmd <- undefined -- atomically (readTBQueue queue)
+      state' <- execute cmd state
+      go state'
+
+data Command
+  = Write ByteString (MVar Int)
+  | Read Int (MVar (Maybe ByteString))
+
+data State = State
+
+initState :: State
+initState = State
+
+execute :: Command -> State -> IO State
+execute (Read ix response) state = do
+  bs <- undefined -- readDB conn ix
+  putMVar response bs
+  undefined
+execute (Write bs response) state = do
+  ix <- undefined -- writeDB conn bs
+  putMVar response ix
+  undefined
+
+httpFrontend :: QueueI Command -> Application
+httpFrontend queue req respond =
+  case requestMethod req of
+    "GET" -> do
+      case parseIndex of
+        Left err -> do
+          respond (responseLBS status400 [] err)
+        Right ix -> do
+          response <- newEmptyMVar
+          -- atomically (writeTBQueue queue (Read ix response))
+          mbs <- takeMVar response
+          case mbs of
+            Nothing ->
+              respond (responseLBS status404 [] (BS8.pack "Not found"))
+            Just bs -> respond (responseLBS status200 [] bs)
+    "POST" -> do
+      bs <- consumeRequestBodyStrict req
+      response <- newEmptyMVar
+      -- atomically (writeTBQueue queue (Write bs response))
+      ix <- takeMVar response :: IO Int
+      respond (responseLBS status200 [] (BS8.pack (show ix)))
+    _otherwise -> do
+      respond (responseLBS status400 [] "Invalid method")
+  where
+    parseIndex :: Either ByteString Int
+    parseIndex = undefined
+  {-
+      case pathInfo req of
+        [txt] -> case decimal txt of
+          Right (ix, _rest) -> Right ix
+          _otherwise -> Left (BS8.pack "parseIndex: GET /:ix, :ix isn't an integer")
+        _otherwise   -> Left (BS8.pack "parseIndex: GET /:ix, :ix missing")
+-}
+
+runFrontEnd :: QueueI Command -> Port -> MVar () -> IO ()
+runFrontEnd queue port ready = runSettings settings (httpFrontend queue)
+  where
+    settings
+      = setPort port
+      $ setBeforeMainLoop (putMVar ready ())
+      $ defaultSettings

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec3/Service.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec3/Service.hs
@@ -109,6 +109,7 @@ httpFrontend queue req respond =
           respond (responseLBS status400 [] "Couldn't parse index")
         Just ix -> do
           response <- newEmptyMVar
+          -- NOTE: We are not checking if the queue is full here...
           qiEnqueue queue (Read ix response)
           mbs <- takeMVar response
           case mbs of

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec3/ServiceTest.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec3/ServiceTest.hs
@@ -1,0 +1,1 @@
+module ATMC.Lec3.ServiceTest where

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec3/ServiceTest.hs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec3/ServiceTest.hs
@@ -1,1 +1,5 @@
 module ATMC.Lec3.ServiceTest where
+
+import ATMC.Lec3.Service
+
+------------------------------------------------------------------------

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec3SMContractTesting.lhs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec3SMContractTesting.lhs
@@ -32,48 +32,29 @@ Plan
 Picture
 -------
 
-XXX:
+```
+               Interface
+                   |
+    Consumer       |     Producer
+                   |
+       ----------> x-------->
+                   |
+  "Collaboration   |  Contract tests
+      tests"       |
 
 ```
-                Interface
-                   |
-                   |
-  Consumer         |   /----\      Producer
-          -------> x--+      +-->
-                   |
-                   |
-```
 
-SUT B: a queue
---------------
+SUT B: a queue (producer of the interface)
+------------------------------------------
 
+> import ATMC.Lec3.QueueInterface
 > import ATMC.Lec3.Queue
 > import ATMC.Lec3.QueueTest
-
-> data QueueI a = QueueI
->   { qiEnqueue :: a -> IO Bool
->   , qiDequeue :: IO (Maybe a)
->   }
-
-> realQueue :: Int -> IO (QueueI a)
-> realQueue size = do
->   q <- newQueue size
->   return QueueI
->     { qiEnqueue = enqueue q
->     , qiDequeue = dequeue q
->     }
-
-> fakeQueue :: Int -> IO (QueueI a)
-> fakeQueue size = do
->   ref <- newIORef (newModel size)
->   return QueueI
->     { qiEnqueue = \x -> atomicModifyIORef' ref (fakeEnqueue x)
->     , qiDequeue = atomicModifyIORef' ref fakeDequeue
->     }
+> import ATMC.Lec3.Service
 
 
-SUT A: web service that depends on the queue
---------------------------------------------
+SUT A: web service (consumer of the interface)
+----------------------------------------------
 
 > sutA = undefined
 
@@ -148,6 +129,12 @@ Why not just spin up the real component B when testing component A?
   For most software systems, between good contract tests and smoke tests there
   shouldn't be much of a gap for bugs to sneak in. For special cases, such as
   distributed systems, we will cover more comprehensive techniques in lecture 5.
+
+Exercises
+---------
+
+0. The fake/model of the queue is thread-safe, but the real implementation
+   isn't! Fix that and do concurrent contract testing.
 
 See also
 --------

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec3SMContractTesting.lhs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec3SMContractTesting.lhs
@@ -50,14 +50,12 @@ SUT B: a queue (producer of the interface)
 > import ATMC.Lec3.QueueInterface
 > import ATMC.Lec3.Queue
 > import ATMC.Lec3.QueueTest
-> import ATMC.Lec3.Service
 
 
 SUT A: web service (consumer of the interface)
 ----------------------------------------------
 
-> sutA = undefined
-
+> import ATMC.Lec3.Service
 
 ---
 
@@ -136,6 +134,19 @@ Exercises
 0. The fake/model of the queue is thread-safe, but the real implementation
    isn't! Fix that and do concurrent contract testing.
 
+1. Introduce an interface for all database interaction, move the current
+   database implementation to `realDb` and introduce fake database instance of
+   the interface.
+
+2. Write contract tests that ensure that the fake database faithfully represents
+   the real one.
+
+3. Once the contract tests pass, switch out the real database for the fake one
+   in the collabortation tests (the testsuite of the web service). Enable timing
+   output in `ghci` with `:set +s`, crank up the number of tests that
+   `QuickCheck` generates, and see if you notice any speed up in the test
+   execution time.
+
 See also
 --------
 
@@ -149,4 +160,15 @@ See also
   [artcile](https://martinfowler.com/articles/consumerDrivenContracts.html);
 
 - [*Integrated Tests Are A Scam*](https://www.youtube.com/watch?v=fhFa4tkFUFw)
-  talk by J.B. Rainsberger (2022).
+  talk by J.B. Rainsberger (2022), this a less ranty version of a talk with the
+  same title that he [gave](https://www.youtube.com/watch?v=VDfX44fZoMc) at
+  DevConFu in 2013.
+
+Summary
+-------
+
+- Using fakes enables to fast and determinstic integration tests and, as we
+  shall see next, makes it easier to introduce faults when testing;
+
+- Contract tests justify the use of fakes, inplace of the real dependencies,
+  when testing a SUT.

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5SimulationTesting.lhs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5SimulationTesting.lhs
@@ -60,6 +60,8 @@ Exercises
    properites from section 8 on correctness from [*Viewstamped Replication
    Revisited*](https://pmg.csail.mit.edu/papers/vr-revisited.pdf) by Barbara
    Liskov and James Cowling (2012)
+- https://making.pusher.com/fuzz-testing-distributed-systems-with-quickcheck/
+- https://fractalscapeblog.wordpress.com/2017/05/05/quickcheck-for-paxos/
 
 See also
 --------

--- a/doc/advanced-testing-mini-course/src/ATMC/Lec5SimulationTesting.lhs
+++ b/doc/advanced-testing-mini-course/src/ATMC/Lec5SimulationTesting.lhs
@@ -60,3 +60,148 @@ Exercises
    properites from section 8 on correctness from [*Viewstamped Replication
    Revisited*](https://pmg.csail.mit.edu/papers/vr-revisited.pdf) by Barbara
    Liskov and James Cowling (2012)
+
+See also
+--------
+
+- Where do these ideas come from?
+
+  The first reference we been able to find is the following concluding remark by
+  Alan Perlis (the first recipient of the Turing Award) about a discussion about
+  a paper on simulation testing by Brian Randell at the first
+  [conference](http://homepages.cs.ncl.ac.uk/brian.randell/NATO/nato1968.PDF) on
+  Software Engineering (this is where we got the term from) in 1968:
+
+    "I’d like to read three sentences to close this issue.
+
+       1. A software system can best be designed if the testing is interlaced with
+          the designing instead of being used after the design.
+
+       2. A simulation which matches the requirements contains the control which
+          organizes the design of the system.
+
+       3. Through successive repetitions of this process of interlaced testing and
+          design the model ultimately becomes the software system itself. I think that it
+          is the key of the approach that has been suggested, that there is no such
+          question as testing things after the fact with simulation models, but that in
+          effect the testing and the replacement of simulations with modules that are
+          deeper and more detailed goes on with the simulation model controlling, as it
+          were, the place and order in which these things are done."
+
+- The idea in its current shape and as applied to distributed systems was
+  introduced(?), or at the very least popularised, by Will Wilson's talk
+  [*Testing Distributed Systems w/ Deterministic
+  Simulation*](https://www.youtube.com/watch?v=4fFDFbi3toc) at Strange Loop
+  (2014) about how they used [simulation
+  testing](https://apple.github.io/foundationdb/testing.html) to test
+  [FoundationDB](https://www.foundationdb.org/) (so well that Kyle "aphyr"
+  Kingsbury didn't feel it was
+  [worth](https://twitter.com/aphyr/status/405017101804396546) Jepsen testing
+  it).
+
+  Watching the talk and rereading the Perlis quote makes one wonder: was the
+  technique independently rediscovered, or had they in fact read the (in)famous
+  1968 NATO software engineering report?
+
+- There's also the more established practice of [discrete-event
+  simulation](https://en.wikipedia.org/wiki/Discrete-event_simulation) which is
+  usually used in different contexts than software testing, but nevertheless is
+  close enough in principle that it's worth taking inspiration from (and indeed
+  the simulation testing people often refer to it).
+
+- Other users of simulation testing include.
+
+    + AWS
+
+Here's a quote from the recently published paper [Millions of Tiny
+Databases](https://www.usenix.org/conference/nsdi20/presentation/brooker) (2020)
+written by three AWS engineers:
+
+ "To solve this problem [testing distributed systems], we picked an approach that
+  is in wide use at Amazon Web Services, which we would like to see broadly
+  adopted: build a test harness which abstracts networking, performance, and
+  other systems concepts (we call it a simworld). The goal of this approach is to
+  allow developers to write distributed systems tests, including tests that
+  simulate packet loss, server failures, corruption, and other failure cases, as
+  unit tests in the same language as the system itself. In this case, these unit
+  tests run inside the developer’s IDE (or with junit at build time), with no need
+  for test clusters or other infrastructure. A typical test which tests
+  correctness under packet loss can be implemented in less than 10 lines of Java
+  code, and executes in less than 100ms. The Physalia team have written hundreds
+  of such tests, far exceeding the coverage that would be practical in any
+  cluster-based or container-based approach.
+
+  The key to building a simworld is to build code against abstract physical layers
+  (such as networks, clocks, and disks). In Java we simply wrap these thin layers
+  in interfaces. In production, the code runs against implementations that use
+  real TCP/IP, DNS and other infrastructure. In the simworld, the implementations
+  are based on in-memory implementa- tions that can be trivially created and torn
+  down. In turn, these in-memory implementations include rich fault-injection
+  APIs, which allow test implementors to specify simple statements like:
+  `net.partitionOff ( PARTITION_NAME , p5.getLocalAddress () ); ...
+  net.healPartition ( PARTITION_NAME );`
+
+  Our implementation allows control down to the packet level, allowing testers
+  to delay, duplicate or drop packets based on matching criteria. Similar
+  capabilities are available to test disk IO. Perhaps the most important testing
+  capability in a distributed database is time, where the framework allows each
+  actor to have it’s own view of time arbitrarily controlled by the test.
+  Simworld tests can even add Byzantine conditions like data corruption, and
+  operational properties like high la- tency. We highly recommend this testing
+  approach, and have continued to use it for new systems we build."
+
+    + Dropbox
+
+      * https://dropbox.tech/infrastructure/rewriting-the-heart-of-our-sync-engine
+      * https://lobste.rs/s/ob6a8z/rewriting_heart_our_sync_engine
+
+    + Basho
+
+     * [Riak](https://speakerdeck.com/jtuple/hansei-property-based-development-of-concurrent-systems)
+       (a distributed NoSQL key-value data store that offers high availability, fault
+       tolerance, operational simplicity, and scalability)
+
+    + IOHK
+
+From their recent
+[paper](http://www.cse.chalmers.se/~rjmh/tfp/proceedings/TFP_2020_paper_11.pdf)
+"Flexibility with Formality: Practical Experience with Agile Formal
+Methods in Large-Scale Functional Programming" (2020):
+
+ "Both the network and consensus layers must make significant use of
+ concurrency which is notoriously hard to get right and to test. We
+ use Software Transactional Memory(STM) to manage the internal state
+ of a node. While STM makes it much easier to write correct concurrent
+ code, it is of course still possible to get wrong, which leads to
+ intermittent failures that are hard to reproduce and debug.
+
+ In order to reliably test our code for such concurrency bugs,
+ we wrote a simulator that can execute the concurrent code with
+ both timing determinism and giving global observability, producing
+ execution traces. This enables us to write property tests that can
+ use the execution traces and to run the tests in a deterministic
+ way so that any failures are always reproducible.  The use of the
+ mini-protocol design pattern, the encoding of protocol interactions
+ in session types and the use of a timing reproducable simulation has
+ yielded several advantages:
+
+   * Adding new protocols (for new functionality) with strong
+     assurance that they will not interact adversly with existing
+     functionality and/or performance consistency.
+
+   * Consistent approaches (re-usable design approaches) to issues
+     of latency hiding, intra mini-protocol flow control and
+     timeouts / progress criteria.
+
+   * Performance consistent protocol layer abstraction /
+     subsitution: construct real world realistic timing for operation
+     without complexity of simulating all the underlying layer protocol
+     complexity. This helps designs / development to maintain performance
+     target awareness during development.
+
+   * Consitent error propagation and mitigation (mini protocols to
+     a peer live/die together) removing issues of resource lifetime
+     management away from mini-protocol designers / implementors."
+
+The simulation code is open source and can be found
+[here](https://github.com/input-output-hk/ouroboros-network/tree/master/io-sim).


### PR DESCRIPTION
- feat(course): towards integrating lec2 checker with lec5 output
- feat(course): implement blackbox history
- refactor(course): remove typeable msg constraint from blackbox history
- fix(course): add missing cases in blackbox history
- refactor(course): clean up main
- feat(course): more on discussion and see alsos, as well as skeleton for lec 6-8
- feat(course): add two more future work chapters
- feat(course): add queue for lec 3 and 4
- feat(course): more on lec 3 code and more text
- feat(course): improve pre-requisites
- feat(course): simplify lec 3 service and add real queue
- feat(course): add a few exercises and a summary for lec 3
- feat(course): finish implementation of lec 3 web service
- feat(course): add note about future fault injection potential
