### PR TITLE
fix(course): make collaboration tests in lec 3 actually run

### DIFF
--- a/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
+++ b/doc/advanced-testing-mini-course/advanced-testing-mini-course.cabal
@@ -93,6 +93,7 @@ library
     Experiment.Simulation
 
   default-language: Haskell2010
+  ghc-options:      -Wall
 
 executable lec5
   main-is:          Main.hs
@@ -108,4 +109,4 @@ executable lec5
 
   hs-source-dirs:   app
   default-language: Haskell2010
-  ghc-options:      -threaded -rtsopts -with-rtsopts=-N -fno-ignore-asserts
+  ghc-options:      -Wall -threaded -rtsopts -with-rtsopts=-N -fno-ignore-asserts

--- a/doc/advanced-testing-mini-course/src/Lec00Introduction.lhs
+++ b/doc/advanced-testing-mini-course/src/Lec00Introduction.lhs
@@ -75,8 +75,8 @@ Table of contents
 
 > module Lec00Introduction where
 
-> import Lec01SMTesting
-> import Lec02ConcurrentSMTesting
-> import Lec03SMContractTesting
-> import Lec04FaultInjection
-> import Lec05SimulationTesting
+> import Lec01SMTesting ()
+> import Lec02ConcurrentSMTesting ()
+> import Lec03SMContractTesting ()
+> import Lec04FaultInjection ()
+> import Lec05SimulationTesting ()

--- a/doc/advanced-testing-mini-course/src/Lec03SMContractTesting.lhs
+++ b/doc/advanced-testing-mini-course/src/Lec03SMContractTesting.lhs
@@ -1,7 +1,5 @@
 > module Lec03SMContractTesting where
 
-> import Data.IORef
-
 Consumer-driven contract testing using state machines
 =====================================================
 
@@ -47,16 +45,16 @@ Picture
 SUT B: a queue (producer of the interface)
 ------------------------------------------
 
-> import Lec03.QueueInterface
-> import Lec03.Queue
-> import Lec03.QueueTest
+> import Lec03.QueueInterface ()
+> import Lec03.Queue ()
+> import Lec03.QueueTest ()
 
 
 SUT A: web service (consumer of the interface)
 ----------------------------------------------
 
-> import Lec03.Service
-> import Lec03.ServiceTest
+> import Lec03.Service ()
+> import Lec03.ServiceTest ()
 
 ---
 

--- a/doc/advanced-testing-mini-course/src/Lec05/EventLoop.hs
+++ b/doc/advanced-testing-mini-course/src/Lec05/EventLoop.hs
@@ -4,14 +4,8 @@
 module Lec05.EventLoop where
 
 import Control.Monad
-import Control.Applicative
 import Control.Concurrent.Async
-import Control.Concurrent.MVar
-import Control.Concurrent.STM
 import Control.Exception
-import Data.ByteString.Lazy (ByteString)
-import Data.IORef
-import Data.Time
 
 import Lec05.Agenda
 import Lec05.Codec
@@ -81,8 +75,8 @@ runWorker d = go
                                   show rawInput)
             Just input -> do
               gen <- rGetStdGen (dRandom d)
-              r <- try (evaluate (step input state gen))
-              case r of
+              res <- try (evaluate (step input state gen))
+              case res of
                 Left (e :: SomeException) ->
                   putStrLn ("step failed, error: " ++ displayException e)
                 Right (outputs, state', gen') -> do
@@ -96,8 +90,8 @@ runWorker d = go
       case r of
         Nothing -> putStrLn ("Lookup of receiver failed, node id: " ++ show (unNodeId nodeId))
         Just (SomeCodecSM codec (SM state _step timeout)) -> do
-          r <- try (evaluate (timeout time state))
-          case r of
+          res <- try (evaluate (timeout time state))
+          case res of
             Left (e :: SomeException) ->
               putStrLn ("timeout failed, error: " ++ displayException e)
             Right (outputs, state') -> do

--- a/doc/advanced-testing-mini-course/src/Lec05/History.hs
+++ b/doc/advanced-testing-mini-course/src/Lec05/History.hs
@@ -6,7 +6,6 @@
 module Lec05.History where
 
 import Control.Concurrent.STM
-import Control.Concurrent.STM.TQueue
 import Data.Typeable
 import Data.TreeDiff (ToExpr)
 

--- a/doc/advanced-testing-mini-course/src/Lec05SimulationTesting.lhs
+++ b/doc/advanced-testing-mini-course/src/Lec05SimulationTesting.lhs
@@ -1,6 +1,6 @@
 > module Lec05SimulationTesting where
 
-> import Lec05.EventLoop
+> import Lec05.EventLoop ()
 
 Simulation testing
 ==================


### PR DESCRIPTION
Problem was we were starting a service each property run, which causes
problems with startup / teardown being too slow and the port being
busy / not ready.
