### PR TITLE
feat(course): Add field if history event was dropped or not

### DIFF
--- a/doc/advanced-testing-mini-course/app/Main.hs
+++ b/doc/advanced-testing-mini-course/app/Main.hs
@@ -37,11 +37,11 @@ main = do
         vrSM me = VR.vrSM (filter (/= me) nodes) me [] smI
         printItem label prefix thing =
           putStrLn $ "\x1b[31m" <> label <> ":\x1b[0m " <> prefix <> show thing
-        printE (HistEvent n bs inp as msgs) = do
+        printE (HistEvent' d (HistEvent n bs inp as msgs)) = do
           putStrLn "\n\x1b[32mNew Entry\x1b[0m"
           printItem "Node" " " n
           printItem "State before" "\n" bs
-          printItem "Input" " " inp
+          printItem "Input" (case d of { DidDrop -> "[DROPPED] "; DidArrive -> " "}) inp
           printItem "State after" "\n" as
           printItem "Sent messages" "" ""
           mapM_ (\x -> putStrLn $ "  " <> show x) msgs
@@ -53,6 +53,6 @@ main = do
       let step :: () -> VRRequest () -> ((), VRResponse ())
           step = undefined
           initModel = undefined
-      assert (linearisable step initModel (interleavings (blackboxHistory history)))
+      assert (linearisable step initModel (interleavings (blackboxHistory (fmap heEvent history))))
              (return ())
     _otherwise       -> eventLoopProduction [SomeCodecSM idCodec echoSM]

--- a/doc/advanced-testing-mini-course/src/Lec05/Debug.hs
+++ b/doc/advanced-testing-mini-course/src/Lec05/Debug.hs
@@ -13,8 +13,8 @@ import Lec05.History
 import Lec05.StateMachine
 import Lec05.Time
 
-toI :: (Int, HistEvent) -> Value
-toI (i, HistEvent n bs inp as msgs) = object
+toI :: (Int, HistEvent') -> Value
+toI (i, HistEvent' _dropped (HistEvent n bs inp as msgs)) = object
   [ "state" .= show (ppEditExpr ansiWlPretty (ediff bs as))
   , "currentEvent" .= object
     [ "from" .= f
@@ -51,8 +51,8 @@ toI (i, HistEvent n bs inp as msgs) = object
       ]
     toD _ = []
 
-toDebugFile :: [HistEvent] -> ByteString
+toDebugFile :: [HistEvent'] -> ByteString
 toDebugFile = encode . map toI . zip [0..]
 
-writeDebugFile :: FilePath -> [HistEvent] -> IO ()
+writeDebugFile :: FilePath -> [HistEvent'] -> IO ()
 writeDebugFile fp xs = writeFile fp (toDebugFile xs)

--- a/doc/advanced-testing-mini-course/src/Lec05/Deployment.hs
+++ b/doc/advanced-testing-mini-course/src/Lec05/Deployment.hs
@@ -67,5 +67,5 @@ newDeployment mode config = case mode of
       , dTimerWheel    = timerWheel
       , dRandom        = random
       , dPids          = Pids []
-      , dAppendHistory = appendHistory history
+      , dAppendHistory = appendHistory history DidArrive
       }

--- a/doc/advanced-testing-mini-course/src/Lec05/History.hs
+++ b/doc/advanced-testing-mini-course/src/Lec05/History.hs
@@ -15,7 +15,14 @@ import Lec05.StateMachine
 
 ------------------------------------------------------------------------
 
-newtype History = History (TQueue HistEvent)
+newtype History = History (TQueue HistEvent')
+
+data Dropped = DidDrop | DidArrive
+
+data HistEvent' = HistEvent'
+  { heDropped :: Dropped
+  , heEvent :: HistEvent
+  }
 
 data HistEvent = forall state req msg resp.
   ( Show state, Show req, Show msg, Show resp
@@ -29,10 +36,10 @@ newHistory = do
   q <- newTQueueIO
   return (History q)
 
-appendHistory :: History -> HistEvent -> IO ()
-appendHistory (History q) ev = atomically (writeTQueue q ev)
+appendHistory :: History -> Dropped -> HistEvent -> IO ()
+appendHistory (History q) dropped ev = atomically (writeTQueue q (HistEvent' dropped ev))
 
-readHistory :: History -> IO [HistEvent]
+readHistory :: History -> IO [HistEvent']
 readHistory (History q) = atomically (flushTQueue q)
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
The information if an event was dropped or not is not stored in the `HistEvent`
type but rather in a new wrapper type named `HistEvent'`. The reason for doing
it this way is that the `Deployment` type still only have:
```
dAppendHistory :: Deployment-> HistEvent -> IO ()
```
So `HistEvent` is part of the interface that the `eventLoop` uses. And the
eventloop should not now if events arrived or not.

Currently all events will eventually arrive in simulation, but when introducing
faults that may not be true. So in the future a faulty `Network` mock could add
to the history dropped messages.