### PR TITLE
minicourse

### DIFF
--- a/doc/advanced-testing-mini-course/src/Lec05/EventLoop.hs
+++ b/doc/advanced-testing-mini-course/src/Lec05/EventLoop.hs
@@ -64,7 +64,9 @@ runWorker d = go
       nTimerEvent <- nextTimer (dTimerWheel d) (dClock d)
       event <- case nTimerEvent of
         None -> eqDequeue (dEventQueue d) NoTimeout
-        Now timerEvent -> return (TimerEventE timerEvent)
+        Now timerEvent -> do
+          popTimer (dTimerWheel d)
+          return (TimerEventE timerEvent)
         Later micros timerEvent -> eqDequeue (dEventQueue d)
                                      (Timeout micros (do
                                        popTimer (dTimerWheel d)

--- a/doc/advanced-testing-mini-course/src/Lec05/EventQueue.hs
+++ b/doc/advanced-testing-mini-course/src/Lec05/EventQueue.hs
@@ -2,6 +2,7 @@ module Lec05.EventQueue where
 
 import Control.Concurrent.STM
 import Data.IORef
+import System.Timeout (timeout)
 
 import Lec05.Agenda
 import Lec05.Event
@@ -9,9 +10,14 @@ import Lec05.Time
 
 ------------------------------------------------------------------------
 
+data DequeueTimeout
+  = NoTimeout
+  | Timeout Int        -- ^ Micro seconds.
+            (IO Event) -- ^ Retry action.
+
 data EventQueue = EventQueue
   { eqEnqueue :: Event -> IO ()
-  , eqDequeue :: IO Event
+  , eqDequeue :: DequeueTimeout -> IO Event
   }
 
 realEventQueue :: Clock -> IO EventQueue
@@ -19,11 +25,17 @@ realEventQueue _clock = do
   q <- newTQueueIO
   return EventQueue
     { eqEnqueue = atomically . writeTQueue q
-    , eqDequeue = atomically (readTQueue q)
+    , eqDequeue = \dequeueTimeout -> case dequeueTimeout of
+        NoTimeout -> atomically (readTQueue q)
+        Timeout micros retry -> do
+          mEvent <- timeout micros (atomically (readTQueue q))
+          case mEvent of
+            Nothing    -> retry
+            Just event -> return event
     }
 
 fakeEventQueue :: Agenda -> Clock -> IO EventQueue
-fakeEventQueue a0 _clock = do
+fakeEventQueue a0 clock = do
   agenda <- newIORef a0
   return EventQueue
     { eqEnqueue = enqueue agenda
@@ -33,11 +45,14 @@ fakeEventQueue a0 _clock = do
     enqueue :: IORef Agenda -> Event -> IO ()
     enqueue agenda event = modifyIORef' agenda (push (getEventTime event, event))
 
-    dequeue :: IORef Agenda -> IO Event
-    dequeue agenda = do
+    dequeue :: IORef Agenda -> DequeueTimeout -> IO Event
+    dequeue agenda NoTimeout = do
       a <- readIORef agenda
       case pop a of
         Nothing -> return (CommandEventE Exit)
         Just ((_time, event), a') -> do
           writeIORef agenda a'
           return event
+    dequeue agenda (Timeout micros retry) = do
+      cModifyCurrentTime clock (addTimeMicros micros)
+      retry

--- a/doc/advanced-testing-mini-course/src/Lec05/TimerWheel.hs
+++ b/doc/advanced-testing-mini-course/src/Lec05/TimerWheel.hs
@@ -2,14 +2,12 @@ module Lec05.TimerWheel where
 
 import Data.Time
 import Data.Fixed
-import Data.Foldable
 import Data.IORef
 import Data.Heap (Entry(Entry), Heap)
 import qualified Data.Heap as Heap
 
 import Lec05.Time
 import Lec05.Event
-import Lec05.EventQueue
 import Lec05.StateMachine
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
- feat(course): activate slow dequeue fault
- docs: add cassandra to examples of simulation testing uses
- fix(course): make timers deterministic
