### PR TITLE
minicourse

### DIFF
--- a/doc/advanced-testing-mini-course/src/Lec03SMContractTesting.lhs
+++ b/doc/advanced-testing-mini-course/src/Lec03SMContractTesting.lhs
@@ -28,18 +28,6 @@ Plan
 How it works
 ------------
 
-```
-               Interface
-                   |
-    Consumer       |     Producer
-                   |
-       ----------> x-------->
-                   |
-  "Collaboration   |  Contract tests
-      tests"       |
-
-```
-
 SUT with real queue
 -------------------
 
@@ -91,22 +79,20 @@ state machine function, update the state variable.
 
 ![](./images/lec3-sm-model-fake-small.jpg)
 
-SUT B: a queue (producer of the interface)
-------------------------------------------
+"Collaboration tests" vs contract tests
+---------------------------------------
 
-> module Lec03SMContractTesting where
+```
+               Interface
+                   |
+    Consumer       |     Producer
+                   |
+       ----------> x-------->
+                   |
+  "Collaboration   |  Contract tests
+      tests"       |
 
-> import Lec03.QueueInterface ()
-> import Lec03.Queue ()
-> import Lec03.QueueTest ()
-
-
-SUT A: web service (consumer of the interface)
-----------------------------------------------
-
-> import Lec03.Service ()
-> import Lec03.ServiceTest ()
-
+```
 
 Consumer-driven contract tests
 ------------------------------
@@ -131,6 +117,18 @@ That way:
      real implementation, then the developers of the consumed API will get a
      failing test and thus a warning about the fact that some assumptions of the
      comsumer might have been broken.
+
+Code
+----
+
+> module Lec03SMContractTesting where
+
+> import Lec03.QueueInterface ()
+> import Lec03.Queue ()
+> import Lec03.QueueTest ()
+
+> import Lec03.Service ()
+> import Lec03.ServiceTest ()
 
 Discussion
 ----------

--- a/doc/advanced-testing-mini-course/src/Lec03SMContractTesting.lhs
+++ b/doc/advanced-testing-mini-course/src/Lec03SMContractTesting.lhs
@@ -221,3 +221,6 @@ Summary
 
 - Contract tests justify the use of fakes, inplace of the real dependencies,
   when testing a SUT.
+
+- State machine testing a component using a model gives us a faithful fake for
+  that component for free.


### PR DESCRIPTION
- feat(course): minor tweaks to lec 1
- feat(course): add demo script for lec 1
- feat(course): add fallacies of distributed computing reference
- feat(course): add diagram of history and possible interleavings
- feat(course): add list of operations under diagrams
- feat(course): add comments for lec 2
- feat(course): add demo script for lec 2
- feat(course): add black- vs white-box discussion to lec 2
- refactor(course): move module declaration and unindent items
- feat(course): lec 3 diagrams
- feat(course): expand a bit on from model to fake
- feat(course): more concise summary
- refactor(course): move stuff around to create a better flow
